### PR TITLE
Fixed edge case in bidsify epoch plotting

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -635,6 +635,10 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
                        ylab = y_label, main = paste0(group, "\n",
                                                      pupil_steps[pstep],
                                                      "\nNO DATA"))
+                  warning(
+                    paste("eyeris: no finite pupillometry data to plot for
+                          current epoch...", "plotting empty epoch plot.")
+                  )
                 }
                 dev.off()
               }

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -621,14 +621,21 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
                   res = 600,
                   pointsize = 6
                 )
-                plot(group_df$timebin, group_df[[pupil_steps[pstep]]],
-                  type = "l", xlab = "time (s)", ylab = y_label,
-                  col = colors[pstep],
-                  main = paste0(
-                    group, "\n", pupil_steps[pstep],
-                    sprintf(" (Run %d)", get_block_numbers(bn))
-                  )
-                )
+                y_values <- group_df[[pupil_steps[pstep]]]
+                if (any(is.finite(y_values))) {
+                  plot(group_df$timebin, y_values,
+                       type = "l", xlab = "time (s)", ylab = y_label,
+                       col = colors[pstep],
+                       main = paste0(group, "\n", pupil_steps[pstep],
+                                     sprintf(" (Run %d)",
+                                             get_block_numbers(bn))))
+                } else {
+                  plot(NA, xlim = range(group_df$timebin, na.rm = TRUE),
+                       ylim = c(0, 1), type = "n", xlab = "time (s)",
+                       ylab = y_label, main = paste0(group, "\n",
+                                                     pupil_steps[pstep],
+                                                     "\nNO DATA"))
+                }
                 dev.off()
               }
             }


### PR DESCRIPTION
When an epoch contains all NaN, plotting the data will throw an error. I included a section in `pipeline-bidsify.R` to handle this edge case.