### PR TITLE
fixed multi-block epoch bug 

### DIFF
--- a/R/pipeline-epoch.R
+++ b/R/pipeline-epoch.R
@@ -377,8 +377,8 @@ epoch_and_baseline_block <- function(x, blk, lab, evs, lims, msg_s, msg_e,
   n_events <- blk$n_events
   block_id <- blk$id
   block_name <- blk$name
-  block_data <- x$timeseries[[block_id]]
-  block_events <- x$events[[block_id]]
+  block_data <- x$timeseries[[block_name]]
+  block_events <- x$events[[block_name]]
 
   dt <- data.table::as.data.table(block_data)
 


### PR DESCRIPTION
When there are more than 9 blocks, the default order those blocks appear in the eyeris object will not be monotonic with respect to the block number (i.e., block_1 will be followed by block_10 rather than block_2). Therefore, when the epoch procedure tries to pull out event and data from block_10 by using the int converted block number (i.e., 10), it will actually extract event and data from block_9 since that would be the 10th block in the eyeris object. Fixed by extracting from eyeris blocks using their names rather than their indices.

## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
<!-- Example: Fixed issue with function parameters (#123) -->

## Breaking Changes

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
