### PR TITLE
glassbox function fixed closing parenthesis bug

### DIFF
--- a/R/pipeline-glassbox.R
+++ b/R/pipeline-glassbox.R
@@ -563,7 +563,9 @@ glassbox <- function(file,
         }
       }
 
-    step_counter <- step_counter + 1
+      step_counter <- step_counter + 1
+    }
+  }
   # generate confounds after all other steps
   if (verbose) {
     cli::cli_alert_success("[  OK  ] - Running eyeris::summarize_confounds()")


### PR DESCRIPTION
Glassbox function was failing due to some parenthesis issues. I believe I adequately closed them. 
