### PR TITLE
RF: #196 deprecation of `pdf_report` argument in `bidsify()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 1.3.0.9000
+Version: 1.2.1.9000
 Date: 2025-06-15
 Authors@R:
   c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,13 @@
-# eyeris 1.3.0 (in development)
+# eyeris 1.2.1.9000 (in development)
 
-The following changes are in progress and available only in the GitHub development version (`v1.3.0.9000`).
+The following changes are in progress and available only in the GitHub development version (`v1.2.1.9000`).
 
 ### ✨ New features
 * tbd...
+
+### 🔧 Minor improvements and fixes
+* RF: Deprecated the `pdf_report` parameter in `bidsify()`.
+  * Please use `html_report = TRUE` instead.
 
 _This version has not yet been released to CRAN._
 

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -96,7 +96,7 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
     )
     html_report <- pdf_report
   }
-  
+
   # setup
   if (is.list(eyeris$timeseries) && !is.data.frame(eyeris$timeseries)) {
     if (!is.null(run_num)) {

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -37,9 +37,6 @@
 #' addition to epoched data. Defaults to TRUE.
 #' @param html_report Logical flag indicating whether to save out the `eyeris`
 #' preprocessing summary report as an HTML file. Defaults to FALSE.
-#' @param pdf_report Logical flag indicating whether to save out the `eyeris`
-#' preprocessing summary report as a PDF file. Note, a valid TeX distribution
-#' must already be installed. Defaults to FALSE.
 #' @param report_seed Random seed for the plots that will appear in the report.
 #' Defaults to 0. See [eyeris::plot()] for a more detailed description.
 #' @param report_epoch_grouping_var_col String name of grouping column to use
@@ -51,8 +48,11 @@
 #' @param verbose A flag to indicate whether to print detailed logging messages.
 #' Defaults to `TRUE`. Set to `False` to suppress messages about the current
 #' processing step and run silently.
+#' @param pdf_report **(Deprecated)** Use `html_report = TRUE` instead.
 #'
 #' @return Invisibly returns `NULL`. Called for its side effects.
+#'
+#' @seealso [lifecycle::deprecate_warn()]
 #'
 #' @examples
 #' # Bleed around blink periods just long enough to remove majority of
@@ -84,10 +84,19 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
                     merge_epochs = FALSE, bids_dir = NULL,
                     participant_id = NULL, session_num = NULL,
                     task_name = NULL, run_num = NULL, merge_runs = FALSE,
-                    save_raw = TRUE, html_report = FALSE,
-                    pdf_report = FALSE, report_seed = 0,
+                    save_raw = TRUE, html_report = FALSE, report_seed = 0,
                     report_epoch_grouping_var_col = "matched_event",
-                    verbose = TRUE) {
+                    verbose = TRUE, pdf_report = deprecated()) {
+  # deprecation warning for pdf_report
+  if (is_present(pdf_report)) {
+    deprecate_warn(
+      "1.3.0",
+      "bidsify(pdf_report)",
+      "bidsify(html_report)"
+    )
+    html_report <- pdf_report
+  }
+  
   # setup
   if (is.list(eyeris$timeseries) && !is.data.frame(eyeris$timeseries)) {
     if (!is.null(run_num)) {
@@ -1728,7 +1737,7 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
       sub = sub, ses = ses, task = task
     )
 
-    render_report(report_output, html = html_report, pdf = pdf_report)
+    render_report(report_output, html = html_report)
   }
 
   invisible(NULL)

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1737,7 +1737,7 @@ bidsify <- function(eyeris, save_all = TRUE, epochs_list = NULL,
       sub = sub, ses = ses, task = task
     )
 
-    render_report(report_output, html = html_report)
+    render_report(report_output)
   }
 
   invisible(NULL)

--- a/R/utils-render_report.R
+++ b/R/utils-render_report.R
@@ -1,4 +1,4 @@
-render_report <- function(rmd_f, html, pdf = FALSE) {
+render_report <- function(rmd_f) {
   rmarkdown::render(rmd_f, output_format = "html_document")
   unlink(rmd_f)
 }

--- a/R/utils-render_report.R
+++ b/R/utils-render_report.R
@@ -1,26 +1,5 @@
-render_report <- function(rmd_f, html, pdf) {
+render_report <- function(rmd_f, html, pdf = FALSE) {
   rmarkdown::render(rmd_f, output_format = "html_document")
-
-  if (pdf) {
-    tryCatch(
-      {
-        rmarkdown::render(rmd_f, output_format = "pdf_document")
-      },
-      error = function(e) {
-        cli::cli_alert_danger(paste(
-          "Could not render eyeris report PDF.",
-          "Do you have a TeX distribution installed?",
-          "If not, consider TinyTeX:\n",
-          "## install.packages('tinytex')\n",
-          "## tinytex::install_tinytex()"
-        ))
-        base_file <- tools::file_path_sans_ext(rmd_f)
-        unlink(paste0(base_file, ".log"))
-        unlink(paste0(base_file, ".tex"))
-      }
-    )
-  }
-
   unlink(rmd_f)
 }
 
@@ -65,7 +44,6 @@ make_report <- function(eyeris, out, plots, ...) {
     "    toc_float: true\n",
     "    toc_depth: 3\n",
     "    number_sections: false\n",
-    "  pdf_document: default\n",
     "---\n\n",
     "\n\n<img src='", sticker_path, "' class='top-right-image'>",
     "\n\n---\n\n## Summary\n",

--- a/man/bidsify.Rd
+++ b/man/bidsify.Rd
@@ -17,10 +17,10 @@ bidsify(
   merge_runs = FALSE,
   save_raw = TRUE,
   html_report = FALSE,
-  pdf_report = FALSE,
   report_seed = 0,
   report_epoch_grouping_var_col = "matched_event",
-  verbose = TRUE
+  verbose = TRUE,
+  pdf_report = deprecated()
 )
 }
 \arguments{
@@ -62,10 +62,6 @@ addition to epoched data. Defaults to TRUE.}
 \item{html_report}{Logical flag indicating whether to save out the \code{eyeris}
 preprocessing summary report as an HTML file. Defaults to FALSE.}
 
-\item{pdf_report}{Logical flag indicating whether to save out the \code{eyeris}
-preprocessing summary report as a PDF file. Note, a valid TeX distribution
-must already be installed. Defaults to FALSE.}
-
 \item{report_seed}{Random seed for the plots that will appear in the report.
 Defaults to 0. See \code{\link[=plot]{plot()}} for a more detailed description.}
 
@@ -79,6 +75,8 @@ epoch-level diagnostic plots, set to \code{NULL}.}
 \item{verbose}{A flag to indicate whether to print detailed logging messages.
 Defaults to \code{TRUE}. Set to \code{False} to suppress messages about the current
 processing step and run silently.}
+
+\item{pdf_report}{\strong{(Deprecated)} Use \code{html_report = TRUE} instead.}
 }
 \value{
 Invisibly returns \code{NULL}. Called for its side effects.
@@ -120,4 +118,7 @@ demo_data |>
   )
 }
 
+}
+\seealso{
+\code{\link[lifecycle:deprecate_soft]{lifecycle::deprecate_warn()}}
 }


### PR DESCRIPTION
### 🔧 Minor improvements and fixes
* RF: #196 - Deprecated the `pdf_report` parameter in `bidsify()`.
  * Please use `html_report = TRUE` instead.