### PR TITLE
FF: add validation for `prev_op` in `zscore_pupil()` function

### DIFF
--- a/R/pipeline-zscore.R
+++ b/R/pipeline-zscore.R
@@ -69,6 +69,26 @@ zscore <- function(eyeris) {
 }
 
 zscore_pupil <- function(x, prev_op) {
+  # validate the previous operation column name
+  if (is.null(prev_op) || length(prev_op) == 0 || prev_op == "") {
+    cli::cli_abort("Previous operation column name is empty or NULL.")
+  }
+
+  if (!prev_op %in% colnames(x)) {
+    cli::cli_abort(paste(
+      "Column '", prev_op, "' not found in data.",
+      "Available columns:", paste(colnames(x), collapse = ", ")
+    ))
+  }
+
+  # check for duplicate suffixes in column name (might indicate corruption)
+  if (grepl("_([^_]+)_\\1", prev_op)) {
+    cli::cli_abort(paste(
+      "Corrupted column name detected:", prev_op,
+      "This might indicate an eyeris pipeline processing error."
+    ))
+  }
+
   pupil_col <- dplyr::sym(prev_op)
 
   x |>


### PR DESCRIPTION
Introduces checks to ensure the previous operation column name is provided, exists in the data, and is not corrupted by duplicate suffixes. These validations improve error handling and help detect pipeline processing issues early.
