### PR TITLE
FF: update event placeholder in example code to `{startstop}`

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -82,7 +82,7 @@
 #' demo_data |>
 #'   eyeris::glassbox() |>
 #'   eyeris::epoch(
-#'     events = "PROBE_{type}_{trial}",
+#'     events = "PROBE_{startstop}_{trial}",
 #'     limits = c(-1, 1), # grab 1 second prior to and 1 second post event
 #'     label = "prePostProbe" # custom epoch label name
 #'   ) |>
@@ -100,7 +100,7 @@
 #' demo_data |>
 #'   eyeris::glassbox() |>
 #'   eyeris::epoch(
-#'     events = "PROBE_{type}_{trial}",
+#'     events = "PROBE_{startstop}_{trial}",
 #'     limits = c(-1, 1),
 #'     label = "prePostProbe"
 #'   ) |>

--- a/man/bidsify.Rd
+++ b/man/bidsify.Rd
@@ -121,7 +121,7 @@ demo_data |>
 demo_data |>
   eyeris::glassbox() |>
   eyeris::epoch(
-    events = "PROBE_{type}_{trial}",
+    events = "PROBE_{startstop}_{trial}",
     limits = c(-1, 1), # grab 1 second prior to and 1 second post event
     label = "prePostProbe" # custom epoch label name
   ) |>
@@ -139,7 +139,7 @@ demo_data <- eyelink_asc_demo_dataset()
 demo_data |>
   eyeris::glassbox() |>
   eyeris::epoch(
-    events = "PROBE_{type}_{trial}",
+    events = "PROBE_{startstop}_{trial}",
     limits = c(-1, 1),
     label = "prePostProbe"
   ) |>


### PR DESCRIPTION
## Changelog entry

FF: update event placeholder in example code to `{startstop}` to resolve name conflict with `type` column name.
