### PR TITLE
BF: #237 fix handling of monocular timeseries csv derivatives and eye metadata

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1329,7 +1329,7 @@ run_bidsify <- function(
       if (is.list(eyeris$timeseries) && length(eyeris$timeseries) > 0) {
         run_data <- eyeris$timeseries[[1]]
       } else {
-        stop("[ERROR] eyeris$timeseries is either not a list or is empty. Cannot access the first element.")
+        cli::cli_abort("[EXIT] eyeris$timeseries is either not a list or is empty. Cannot access the first element.")
       }
       # use run_num if provided, otherwise default to 1
       run_num_to_use <- if (!is.null(run_num)) {
@@ -1337,7 +1337,7 @@ run_bidsify <- function(
         if (!is.na(run_num_numeric)) {
           sprintf("%02d", run_num_numeric)
         } else {
-          warning("[WARNING] Invalid run_num provided. Defaulting to '01'.")
+          cli::cli_alert_warning("[WARN] Invalid run_num provided. Defaulting to '01'.")
           "01"
         }
       } else {

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1332,7 +1332,17 @@ run_bidsify <- function(
         stop("[ERROR] eyeris$timeseries is either not a list or is empty. Cannot access the first element.")
       }
       # use run_num if provided, otherwise default to 1
-      run_num_to_use <- if (!is.null(run_num)) sprintf("%02d", as.numeric(run_num)) else "01"
+      run_num_to_use <- if (!is.null(run_num)) {
+        run_num_numeric <- suppressWarnings(as.numeric(run_num))
+        if (!is.na(run_num_numeric)) {
+          sprintf("%02d", run_num_numeric)
+        } else {
+          warning("[WARNING] Invalid run_num provided. Defaulting to '01'.")
+          "01"
+        }
+      } else {
+        "01"
+      }
       f <- make_bids_fname(
         sub_id = sub,
         ses_id = ses,

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1326,7 +1326,11 @@ run_bidsify <- function(
       }
     } else {
       # single run (monocular) case: write the raw timeseries
-      run_data <- eyeris$timeseries[[1]]
+      if (is.list(eyeris$timeseries) && length(eyeris$timeseries) > 0) {
+        run_data <- eyeris$timeseries[[1]]
+      } else {
+        stop("[ERROR] eyeris$timeseries is either not a list or is empty. Cannot access the first element.")
+      }
       # use run_num if provided, otherwise default to 1
       run_num_to_use <- if (!is.null(run_num)) sprintf("%02d", as.numeric(run_num)) else "01"
       f <- make_bids_fname(

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1324,6 +1324,34 @@ run_bidsify <- function(
           }
         })
       }
+    } else {
+      # single run (monocular) case: write the raw timeseries
+      run_data <- eyeris$timeseries[[1]]
+      # use run_num if provided, otherwise default to 1
+      run_num_to_use <- if (!is.null(run_num)) sprintf("%02d", as.numeric(run_num)) else "01"
+      f <- make_bids_fname(
+        sub_id = sub,
+        ses_id = ses,
+        task_name = task,
+        run_num = run_num_to_use,
+        desc = "timeseries",
+        eye_suffix = eye_suffix
+      )
+      if (verbose) {
+        alert(
+          "info",
+          "[INFO] Writing raw pupil timeseries to '%s'...",
+          file.path(dir, p, f)
+        )
+      }
+      write.csv(run_data, file.path(dir, p, f), row.names = FALSE)
+      if (verbose) {
+        alert(
+          "success",
+          "[OKAY] Raw pupil timeseries written to: '%s'",
+          file.path(dir, p, f)
+        )
+      }
     }
   }
 

--- a/R/pipeline-loadasc.R
+++ b/R/pipeline-loadasc.R
@@ -280,6 +280,14 @@ load_asc <- function(
 #' @keywords internal
 process_eyeris_data <- function(x, block, eye, hz, pupil_type, file, binoc, binoc_mode) {
   # raw data processing
+  if (eye == "left") {
+    eye_meta <- "L"
+  } else if (eye == "right") {
+    eye_meta <- "R"
+  } else {
+    eye_meta <- eye
+  }
+
   raw_df <- x$raw |>
     dplyr::select(
       block,
@@ -289,7 +297,7 @@ process_eyeris_data <- function(x, block, eye, hz, pupil_type, file, binoc, bino
       eye_y = yp
     ) |>
     dplyr::mutate(
-      eye = eye,
+      eye = eye_meta,
       hz = hz,
       type = pupil_type
     ) |>


### PR DESCRIPTION
Fixed issue where raw pupil timeseries was not writing out to target csv files in single run (monocular) cases in pipeline-bidsify.R. Also updated process_eyeris_data in pipeline-loadasc.R to set eye metadata to 'L' or 'R' for left/right eyes, improving consistency in output.

## Changelog entry

- BF: Ensure full raw timeseries `.csv` file is written by `bidsify()` for single-run (monocular) data, including cases with or without epoching and with run number override. Previously, the file was only written for multi-run data by @shawntz in #240.

### Summary

This PR fixes an issue where the full raw timeseries `.csv` file was not being written by `bidsify()` for single-run (monocular) eyeris data. The bug affected all combinations of:
- single .asc file with or without epoching
- with or without run number override

Previously, the raw timeseries was only saved for multi-run data. This update adds logic to ensure the file is also written for single-run data, matching the behavior for multi-run cases.

### Details

- Adds a code path in `run_bidsify()` to write the raw timeseries `.csv` for single-run (monocular) data.
- Uses the correct run number (including override if provided) and BIDS-compliant file naming.
- Ensures `save_all = TRUE` now works as expected for all data configurations.

### Closes

Fixes #237 

---

**Tested scenarios:**
- Single run .asc with original run num (no epoch) [monocular]
- Single run .asc with run num override (no epoch) [monocular]
- Single run .asc with original run num (with epoch) [monocular]
- Single run .asc with run num override (with epoch) [monocular]
- Multiple run .asc (no epoch) [monocular]
- Multiple run .asc (with epoch) [monocular]

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
