### PR TITLE
FF: #236 sprintf log message parsing for blinks/events writing in pipeline-bidsify.R

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -508,7 +508,7 @@ run_bidsify <- function(
     )
 
     if (verbose) {
-      cli::cli_alert_info("[INFO] Writing blinks data to '%s'...", file.path(dir, p, bids_fname))
+      alert("info", "[INFO] Writing blinks data to '%s'...", file.path(dir, p, bids_fname))
     }
 
     if (is_binocular_object(eyeris)) {
@@ -525,7 +525,7 @@ run_bidsify <- function(
     }
 
     if (verbose) {
-      cli::cli_alert_success("[OKAY] Blinks data written to: '%s'", file.path(dir, p, bids_fname))
+      alert("success", "[OKAY] Blinks data written to: '%s'", file.path(dir, p, bids_fname))
     }
   }
 
@@ -540,7 +540,7 @@ run_bidsify <- function(
     )
 
     if (verbose) {
-      cli::cli_alert_info("[INFO] Writing events data to '%s'...", file.path(dir, p, bids_fname))
+      alert("info", "[INFO] Writing events data to '%s'...", file.path(dir, p, bids_fname))
     }
 
     if (is_binocular_object(eyeris)) {
@@ -557,7 +557,7 @@ run_bidsify <- function(
     }
 
     if (verbose) {
-      cli::cli_alert_success("[OKAY] Events data written to: '%s'", file.path(dir, p, bids_fname))
+      alert("success", "[OKAY] Events data written to: '%s'", file.path(dir, p, bids_fname))
     }
   }
 


### PR DESCRIPTION
Updated verbose logging in run_bidsify to use the alert() function instead of cli::cli_alert_info and cli::cli_alert_success for consistency.

## Changelog entry

- FF (#236): Certain sprintf-formatted log messages (e.g., those with '%s') for blinks/events writing in `pipeline-bidsify.R` now parse and display correctly in the logger by using the internal `alert()` wrapper by @shawntz in #241.

### Problem Addressed

This PR addresses issue #236, where a small subset of sprintf-formatted log messages (notably those with '%s') were not being parsed or displayed correctly in the logger for blinks and events data writing steps. The direct calls to cli::cli_alert_info and cli::cli_alert_success have been replaced with the internal alert() wrapper, which ensures proper sprintf formatting and consistent logging behavior.

### Closes

#236

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
