### PR TITLE
FF: #238 show filtered epochs info only when epochs exist

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -413,7 +413,7 @@ run_bidsify <- function(
   n_epochs <- length(epochs)
   any_epochs <- n_epochs > 0
 
-  if (verbose) {
+  if (verbose && any_epochs) {
     cli::cli_alert_info(
       sprintf("[INFO] Filtered epochs: %s", paste(epochs, collapse = ", "))
     )


### PR DESCRIPTION
Updates the verbose logging to display filtered epochs information only if there are any epochs present, preventing unnecessary info messages when no epochs are available.

## Changelog entry

FF: #238 Only log `[INFO] Filtered epochs: ...` when data is epoched by @shawntz in #242.

### Problem Addressed
The `[INFO] Filtered epochs: ...` message was being logged even when the data was not epoched, which could be confusing for users working with non-epoched data.

### Key Changes and Enhancements (Targeting `v2.1.1` `Patch` Release)
The log message is now only shown if there are any filtered epochs (i.e., if the data is epoched); this prevents unnecessary or misleading log output for non-epoched data.

### Closes

#238

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
