### PR TITLE
CHORE: #239 remove duplicate logging and standardize log level for gaze heatmap creation

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -2280,8 +2280,7 @@ run_bidsify <- function(
         dev.off()
 
         if (verbose) {
-          alert("info", "Created gaze heatmap for run-%02d", i_run)
-          alert("info", "[INFO] Created gaze heatmap for run-%02d", i_run)
+          alert("success", "[OKAY] Created gaze heatmap for run-%02d", i_run)
         }
       }
 
@@ -2529,7 +2528,7 @@ run_bidsify <- function(
               dev.off()
 
               if (verbose) {
-                alert("info", "[INFO] Created gaze heatmap for epoch %s (run-%02d)", group, run_dir_num)
+                alert("success", "[OKAY] Created gaze heatmap for epoch %s (run-%02d)", group, run_dir_num)
               }
             }
           }


### PR DESCRIPTION
Changed alert type from `info` to `success` and updated message prefix from `[INFO]` to `[OKAY]` for gaze heatmap creation notifications in run_bidsify, as well as removed the duplicate logging event.

## Changelog entry

- CHORE (#239) duplicate and inconsistent logging for gaze heatmap creation: Removed duplicate logging events for "Created gaze heatmap" in `bidsify()` pipeline. The log message now appears only once per run and uses the `[OKAY]` log level for both run-level and epoch-level heatmap creation, improving clarity and consistency in logs, by @shawntz in #243.

### Problem Addressed

Fixes #239. The pipeline was emitting two log messages for each created gaze heatmap:
- ℹ Created gaze heatmap for run-01
- ℹ [INFO] Created gaze heatmap for run-01

This was redundant and cluttered the logs. Additionally, the log level was `[INFO]` instead of `[OKAY]`, which is the new standard for successful actions.

### Key Changes and Enhancements (Targeting `v2.1.1` `Patch` Release)

- Removed the first (redundant) log message for gaze heatmap creation in `pipeline-bidsify.R`.
- Changed the log level for the remaining message from `[INFO]` to `[OKAY]` for both run-level and epoch-level heatmap creation.
- Ensured consistency with other success log messages in the pipeline.

### Closes
#239

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
