### PR TITLE
CHORE: fix pkgdown CI deployment triggers

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,5 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
 name: pkgdown
 
 permissions: read-all
@@ -16,6 +17,8 @@ on:
         - '_pkgdown.yml'
         - 'DESCRIPTION'
   pull_request:
+    branches:
+        - release/**
     paths:
         - 'NEWS.md'
         - 'README.md'


### PR DESCRIPTION
## Changelog entry

CHORE: adjust pkgdown CI deployment trigger conditions for PRs to be more specific about which branches should trigger the workflow by @shawntz in #245.

### Problem Addressed

This PR updates the GitHub Actions workflow configuration for pkgdown CI deployment to refine when the workflow is triggered.

- Added branch filtering for pull request triggers to only run on release branches
- Added a blank line for formatting consistency

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
