### PR TITLE
FF: handle `glue` interpolation errors in `log_message()`

### DIFF
--- a/R/core-logging.R
+++ b/R/core-logging.R
@@ -45,13 +45,16 @@ log_message <- function(
 
   # apply glue interpolation if there are braces, but handle errors gracefully
   if (grepl("\\{.*\\}", message_text)) {
-    tryCatch({
-      message_text <- glue::glue(message_text, .envir = .envir)
-    }, error = function(e) {
-      # if glue fails, just use the original message without interpolation
-      # i.e., this handles cases where {} contains JSON, structured data, etc.
-      message_text <<- message_text
-    })
+    tryCatch(
+      {
+        message_text <- glue::glue(message_text, .envir = .envir)
+      },
+      error = function(e) {
+        # if glue fails, just use the original message without interpolation
+        # i.e., this handles cases where {} contains JSON, structured data, etc.
+        message_text <<- message_text
+      }
+    )
   }
 
   full_message <- paste(get_log_timestamp(), paste0("[", level, "]"), message_text)

--- a/R/core-logging.R
+++ b/R/core-logging.R
@@ -39,19 +39,23 @@ log_message <- function(
     return(invisible(NULL))
   }
 
-  # Collapse multiple strings with spaces
+  # collapse multiple strings with spaces
   message_parts <- list(...)
   message_text <- paste(message_parts, collapse = " ")
 
-  # Apply glue interpolation if there are braces
+  # apply glue interpolation if there are braces, but handle errors gracefully
   if (grepl("\\{.*\\}", message_text)) {
-    message_text <- glue::glue(message_text, .envir = .envir)
+    tryCatch({
+      message_text <- glue::glue(message_text, .envir = .envir)
+    }, error = function(e) {
+      # if glue fails, just use the original message without interpolation
+      # i.e., this handles cases where {} contains JSON, structured data, etc.
+      message_text <<- message_text
+    })
   }
 
-  # Prepend timestamp and log level
   full_message <- paste(get_log_timestamp(), paste0("[", level, "]"), message_text)
 
-  # Call appropriate cli function based on level
   switch(
     level,
     "INFO" = cli::cli_alert_info(full_message, wrap = wrap),


### PR DESCRIPTION
## Changelog entry

FF: Updated the `log_message()` function to use `tryCatch` when applying `glue` interpolation, ensuring that errors (e.g., from malformed braces or embedded `JSON`) do not interrupt logging; now, the original message is used if interpolation fails, by @shawntz in #258.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
