### PR TITLE
ENH: improve figures zipping and cleanup after report generation

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,5 +1,5 @@
 [format]
-line-width = 90
+line-width = 80
 indent-width = 2
 indent-style = "space"
 line-ending = "native"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 2.1.1.9002
-Date: 2025-08-02
+Version: 2.1.1.9003
+Date: 2025-08-03
 Language: en-US
 Authors@R: 
   c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,24 @@
+# eyeris 2.1.1.9003 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
+
+## ⚠ **development version** — unreleased
+_Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
+
+- - **ENH**: Added post-render cleanup of figures directories in `pipeline-bidsify.R`. Enhanced `zip_and_cleanup_source_figures` to remove existing zip files before reprocessing, move new zip files to the parent figures directory, and delete run directories after successful zipping. This streamlines figures management and prevents leftover files from previous runs, by @shawntz in #261.
+
 # eyeris 2.1.1.9002 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
 
 ## ⚠ **development version** — unreleased
 _Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
 
 - **NF - DuckDB database integration**: Added optional `DuckDB` database functionality to `bidsify()` as an alternative to CSV files for large-scale analyses. When `db_enabled = TRUE`, all `eyeris` data (timeseries, epochs, events, blinks, confounds) are written to a centralized database for efficient querying and analysis. Features include seamless out-of-the-box configuration, user-friendly database functions (`eyeris_db_collect()`, `eyeris_db_connect()`, `eyeris_db_read()`, `eyeris_db_list_tables()`), and `dplyr`-style data access. CSV file generation can be optionally disabled with `csv_enabled = FALSE` for cloud compute environments, by @shawntz in #256.
+
+- **DOC**: Added a comprehensive 'Internal API Reference' vignette documenting all internal functions for advanced users and developers and updated the README to link to the new vignette/included it in the pkgdown docs site configuration, by @shawntz in #257.
+
+- **RF**: Updated documentation and comments across multiple files to improve clarity and align terminology throughout the codebase, especially in function descriptions, parameter names, and return value documentation, by @shawntz in #257.
+
+- **FF**: Updated the `log_message()` function to use `tryCatch` when applying `glue` interpolation, ensuring that errors (e.g., from malformed braces or embedded `JSON`) do not interrupt logging; now, the original message is used if interpolation fails, by @shawntz in #258.
+
+- **CHORE**: Add a GitHub Actions workflow to auto-render vignettes and publish them to the `eyeris` GitHub repo wiki, by @shawntz in #259.
 
 ## 🚨 **Breaking changes & deprecations**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,44 @@
 ## ⚠ **development version** — unreleased
 _Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
 
-- - **ENH**: Added post-render cleanup of figures directories in `pipeline-bidsify.R`. Enhanced `zip_and_cleanup_source_figures` to remove existing zip files before reprocessing, move new zip files to the parent figures directory, and delete run directories after successful zipping. This streamlines figures management and prevents leftover files from previous runs, by @shawntz in #261.
+- **ENH**: Added post-render cleanup of figures directories in `pipeline-bidsify.R`. Enhanced `zip_and_cleanup_source_figures` to remove existing zip files before reprocessing, move new zip files to the parent figures directory, and delete run directories after successful zipping. This streamlines figures management and prevents leftover files from previous runs, by @shawntz in #261.
+
+- **ENH**: Added post-render cleanup of figures directories in `pipeline-bidsify.R`. Enhanced `zip_and_cleanup_source_figures` to remove existing zip files before reprocessing, move new zip files to the parent figures directory, and delete run directories after successful zipping. This streamlines figures management and prevents leftover files from previous runs, by @shawntz in #261.
+
+  > Further cleans up number of derived files in `eyeris` BIDS directories (which is especially useful for cloud compute deployments).
+  >
+  > The new behavior will be:
+  > 
+  > 1. Create zip files in the `figures/` directory (i.e., one level up from the run directories)
+  > 2. Remove existing zip files when reprocessing
+  > 3. Remove the entire `run-XX/` directories after successful zip creation
+  >
+  > As such, the final file structure will be:
+  
+  ```bash
+    sub-01/
+    └── ses-enc/
+        ├── sub-01.html
+        └── source/
+            ├── figures/
+            │   ├── run-01.zip  # now contains all images from run-01/
+            │   ├── run-02.zip  # now contains all images from run-02/
+            │   └── run-03.zip  # now contains all images from run-03/
+            └── logs/
+                ├── run-01_metadata.json
+                ├── run-02_metadata.json
+                └── run-03_metadata.json
+  ```
+
+## 🔧 Minor improvements and fixes
+
+- **RF - post-render cleanup to remove figures directory**: The `cleanup_source_figures_post_render()` function now removes the entire `source/figures` directory after report generation, as images are embedded in the `HTML`. Documentation and comments updated to reflect this change, and unused parameters are noted for compatibility, by @shawntz in #261.
+
+- **RF - increase zip file embed size limit to 1GB**: Raised the maximum allowed zip file size for data `URL` embedding from `10MB` to `1GB` in `print_lightbox_img_html()`. Updated warning message to reflect the new limit, by @shawntz in #261.
+
+- **RF - update report title in `make_report` function**: Changed the report title from 'preprocessing summary report' to 'preprocessing report' for consistency and clarity, by @shawntz in #261.
+
+- **CHORE - update logo image URL**: Changed the `logo` image source in `README` files to use a `GitHub raw URL` for better compatibility, by @shawntz in #261.
 
 # eyeris 2.1.1.9002 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
 

--- a/R/core-logging.R
+++ b/R/core-logging.R
@@ -57,7 +57,11 @@ log_message <- function(
     )
   }
 
-  full_message <- paste(get_log_timestamp(), paste0("[", level, "]"), message_text)
+  full_message <- paste(
+    get_log_timestamp(),
+    paste0("[", level, "]"),
+    message_text
+  )
 
   switch(
     level,
@@ -85,7 +89,12 @@ log_message <- function(
 #' }
 #'
 #' @keywords internal
-log_info <- function(..., verbose = TRUE, wrap = TRUE, .envir = parent.frame()) {
+log_info <- function(
+  ...,
+  verbose = TRUE,
+  wrap = TRUE,
+  .envir = parent.frame()
+) {
   log_message("INFO", ..., verbose = verbose, wrap = wrap, .envir = .envir)
 }
 
@@ -104,7 +113,12 @@ log_info <- function(..., verbose = TRUE, wrap = TRUE, .envir = parent.frame()) 
 #' }
 #'
 #' @keywords internal
-log_success <- function(..., verbose = TRUE, wrap = TRUE, .envir = parent.frame()) {
+log_success <- function(
+  ...,
+  verbose = TRUE,
+  wrap = TRUE,
+  .envir = parent.frame()
+) {
   log_message("OKAY", ..., verbose = verbose, wrap = wrap, .envir = .envir)
 }
 
@@ -123,7 +137,12 @@ log_success <- function(..., verbose = TRUE, wrap = TRUE, .envir = parent.frame(
 #' }
 #'
 #' @keywords internal
-log_warn <- function(..., verbose = TRUE, wrap = TRUE, .envir = parent.frame()) {
+log_warn <- function(
+  ...,
+  verbose = TRUE,
+  wrap = TRUE,
+  .envir = parent.frame()
+) {
   log_message("WARN", ..., verbose = verbose, wrap = wrap, .envir = .envir)
 }
 

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1949,6 +1949,13 @@ run_bidsify <- function(
     )
 
     render_report(report_output)
+    
+    # zip and cleanup figures directories after report generation
+    cleanup_source_figures_post_render(
+      report_path = report_path,
+      eye_suffix = eye_suffix,
+      verbose = verbose
+    )
   }
 
   # disconnect from DB

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1757,168 +1757,33 @@ run_bidsify <- function(
           epochs_out <- file.path(run_dir, names(epochs_to_save)[i])
           check_and_create_dir(epochs_out, verbose = verbose)
 
-          epoch_groups <- as.vector(unique(epochs_to_save[[i]][[bn]][
-            report_epoch_grouping_var_col
-          ])[[1]])
+          # create zip file with all epoch images for this run/epoch combination
+          epoch_zip_path <- create_epoch_images_zip(
+            epochs_to_save = epochs_to_save,
+            epoch_index = i,
+            block_name = bn,
+            run_dir_num = run_dir_num,
+            epochs_out = epochs_out,
+            pupil_steps = pupil_steps,
+            eyeris_object = eyeris,
+            eye_suffix = eye_suffix,
+            report_epoch_grouping_var_col = report_epoch_grouping_var_col,
+            verbose = verbose
+          )
 
-          for (group in epoch_groups) {
-            group_df <- epochs_to_save[[i]][[bn]]
-            group_df <- group_df[group_df[[report_epoch_grouping_var_col]] == group, ]
-
-            for (pstep in seq_along(pupil_steps)) {
-              if (grepl("z", pupil_steps[pstep])) {
-                y_units <- "(z)"
-              } else {
-                y_units <- "(a.u.)"
-              }
-
-              colorpal <- eyeris_color_palette()
-              colors <- c("black", colorpal)
-
-              y_label <- paste("pupil size", y_units)
-
-              file_out <- file.path(
-                epochs_out,
-                sprintf("run-%02d_%s_%d", run_dir_num, group, pstep)
-              )
-
-              if (!is.null(eye_suffix)) {
-                file_out <- paste0(file_out, "_", eye_suffix)
-              }
-
-              file_out <- paste0(file_out, ".png")
-
-              png(
-                file_out,
-                width = 3.25,
-                height = 2.5,
-                units = "in",
-                res = 600,
-                pointsize = 6
-              )
-              y_values <- group_df[[pupil_steps[pstep]]]
-              if (any(is.finite(y_values))) {
-                plot(
-                  group_df$timebin,
-                  y_values,
-                  type = "l",
-                  xlab = "time (s)",
-                  ylab = y_label,
-                  col = colors[pstep],
-                  main = paste0(
-                    group,
-                    "\n",
-                    pupil_steps[pstep],
-                    sprintf(" (Run %d)", run_dir_num)
-                  )
-                )
-              } else {
-                plot(
-                  NA,
-                  xlim = range(group_df$timebin, na.rm = TRUE),
-                  ylim = c(0, 1),
-                  type = "n",
-                  xlab = "time (s)",
-                  ylab = y_label,
-                  main = paste0(group, "\n", pupil_steps[pstep], "\nNO DATA")
-                )
-                log_warn(
-                  "eyeris: no finite pupillometry data to plot for current epoch... plotting empty epoch plot.",
-                  verbose = verbose
-                )
-                text(0.5, 0.5, "No valid data", cex = 0.8, col = "red")
-              }
-              dev.off()
-            }
-          }
-
-          for (group in epoch_groups) {
-            group_df <- epochs_to_save[[i]][[bn]]
-            group_df <- group_df[group_df[[report_epoch_grouping_var_col]] == group, ]
-
-            if (
-              all(c("eye_x", "eye_y") %in% colnames(group_df)) &&
-                all(c("screen.x", "screen.y") %in% colnames(eyeris$info))
-            ) {
-              heatmap_filename <- file.path(
-                epochs_out,
-                sprintf("run-%02d_%s_gaze_heatmap", run_dir_num, group)
-              )
-
-              if (!is.null(eye_suffix)) {
-                heatmap_filename <- paste0(heatmap_filename, "_", eye_suffix)
-              }
-
-              heatmap_filename <- paste0(heatmap_filename, ".png")
-
-              png(
-                heatmap_filename,
-                width = 6,
-                height = 4,
-                units = "in",
-                res = 300,
-                pointsize = 10
-              )
-
-              tryCatch(
-                {
-                  plot_gaze_heatmap(
-                    eyeris = group_df,
-                    block = run_dir_num,
-                    screen_width = eyeris$info$screen.x,
-                    screen_height = eyeris$info$screen.y,
-                    n_bins = 30,
-                    col_palette = "viridis",
-                    main = sprintf("%s\nGaze Heatmap (run-%02d)", group, run_dir_num),
-                    eye_suffix = eye_suffix
-                  )
-                },
-                error = function(e) {
-                  plot(
-                    NA,
-                    xlim = c(0, 1),
-                    ylim = c(0, 1),
-                    type = "n",
-                    xlab = "",
-                    ylab = "",
-                    main = paste("Error creating gaze heatmap for epoch", group)
-                  )
-                  text(0.5, 0.5, paste("Error:", e$message), cex = 0.8, col = "red")
-                }
-              )
-
-              dev.off()
-
-              log_success(
-                "Created gaze heatmap for epoch {group} (run-{sprintf('%02d', run_dir_num)})",
-                verbose = verbose
-              )
-            }
-          }
-
-          if (any_epochs) {
-            epochs <- list.files(
-              epochs_out,
-              full.names = FALSE,
-              pattern = "\\.(jpg|jpeg|png|gif)$",
-              ignore.case = TRUE
-            )
-
-            epochs <- file.path(
+          if (any_epochs && file.exists(epoch_zip_path)) {
+            # create relative path for HTML display
+            zip_relative_path <- file.path(
               "source",
               "figures",
               sprintf("run-%02d", run_dir_num),
               names(epochs_to_save)[i],
-              epochs
+              basename(epoch_zip_path)
             )
-
-            if (!is.null(eye_suffix)) {
-              epochs <- epochs[grepl(eye_suffix, epochs)]
-            }
 
             make_gallery(
               eyeris,
-              epochs,
+              epoch_zip_path, # pass absolute path for file finding
               report_path,
               sprintf(
                 "%s%s",

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -342,7 +342,11 @@ run_bidsify <- function(
     log_info("Only 1 block detected...", verbose = verbose)
 
     original_block_name <- names(eyeris$timeseries)[1]
-    original_block_number <- substr(original_block_name, 7, nchar(original_block_name))
+    original_block_number <- substr(
+      original_block_name,
+      7,
+      nchar(original_block_name)
+    )
     if (is.null(run_num)) {
       run_num_stripped <- as.character(as.integer(original_block_number))
       run_num <- as.character(as.integer(original_block_number))
@@ -352,7 +356,10 @@ run_bidsify <- function(
     new_block_name <- paste0("block_", run_num_stripped)
 
     if (!is.null(run_num)) {
-      log_info("Using run_num = {run_num} for single block data", verbose = verbose)
+      log_info(
+        "Using run_num = {run_num} for single block data",
+        verbose = verbose
+      )
 
       names(eyeris$timeseries)[1] <- new_block_name
 
@@ -386,7 +393,9 @@ run_bidsify <- function(
           ] <- new_block_name
 
           if (!is.null(epoch_info)) {
-            names(epoch_info)[names(epoch_info) == original_block_name] <- new_block_name
+            names(epoch_info)[
+              names(epoch_info) == original_block_name
+            ] <- new_block_name
             eyeris[[epoch_name]]$info <- epoch_info # <-- ensure changes are saved back
           }
 
@@ -505,7 +514,10 @@ run_bidsify <- function(
   any_epochs <- n_epochs > 0
 
   if (verbose && any_epochs) {
-    log_info("Filtered epochs: {paste(epochs, collapse = ', ')}", verbose = verbose)
+    log_info(
+      "Filtered epochs: {paste(epochs, collapse = ', ')}",
+      verbose = verbose
+    )
   }
 
   if (save_all && any_epochs) {
@@ -569,7 +581,10 @@ run_bidsify <- function(
               {
                 DBI::dbExecute(db_con, drop_query)
                 tables_cleaned <- tables_cleaned + 1
-                log_info("Dropped table: {table_name} for sub-{sub}", verbose = verbose)
+                log_info(
+                  "Dropped table: {table_name} for sub-{sub}",
+                  verbose = verbose
+                )
               },
               error = function(e) {
                 log_warn(
@@ -587,7 +602,10 @@ run_bidsify <- function(
         }
       },
       error = function(e) {
-        log_warn("Error during database cleanup: {e$message}", verbose = verbose)
+        log_warn(
+          "Error during database cleanup: {e$message}",
+          verbose = verbose
+        )
       }
     )
   }
@@ -769,7 +787,10 @@ run_bidsify <- function(
           log_info("Processing run {i} for epoch {epoch_id}", verbose = verbose)
 
           if (is.null(run_epochs)) {
-            log_warn("Skipping run {i} for epoch {epoch_id} - no data", verbose = verbose)
+            log_warn(
+              "Skipping run {i} for epoch {epoch_id} - no data",
+              verbose = verbose
+            )
             next
           }
 
@@ -831,7 +852,9 @@ run_bidsify <- function(
         for (block_name in block_names) {
           block_data <- epoch_entry[[block_name]]
           if (
-            is.null(block_data) || !is.data.frame(block_data) || nrow(block_data) == 0
+            is.null(block_data) ||
+              !is.data.frame(block_data) ||
+              nrow(block_data) == 0
           ) {
             log_warn(
               "Skipping block {block_name} for epoch {epoch_id} - empty or invalid data",
@@ -847,7 +870,12 @@ run_bidsify <- function(
 
           evs <- get_epoch_events(eyeris, epoch_id, verbose)
           c_bline <- has_baseline(eyeris, current_label, verbose)
-          bline_evs <- get_baseline_events(eyeris, epoch_id, block_name, verbose)
+          bline_evs <- get_baseline_events(
+            eyeris,
+            epoch_id,
+            block_name,
+            verbose
+          )
           bline_type <- get_baseline_type(eyeris, epoch_id, block_name, verbose)
 
           # extract run number from block name
@@ -893,7 +921,10 @@ run_bidsify <- function(
           any_written <- TRUE
         }
         if (!any_written && verbose) {
-          log_warn("No valid blocks found for epoch {epoch_id}", verbose = verbose)
+          log_warn(
+            "No valid blocks found for epoch {epoch_id}",
+            verbose = verbose
+          )
         }
       }
     }
@@ -948,7 +979,10 @@ run_bidsify <- function(
         if (!is.na(run_num_numeric)) {
           sprintf("%02d", run_num_numeric)
         } else {
-          log_warn("Invalid run_num provided. Defaulting to '01'.", verbose = verbose)
+          log_warn(
+            "Invalid run_num provided. Defaulting to '01'.",
+            verbose = verbose
+          )
           "01"
         }
       } else {
@@ -1080,9 +1114,9 @@ run_bidsify <- function(
         block_name <- paste0("block_", block)
         if (block_name %in% names(eyeris$confounds$unepoched_timeseries)) {
           single_block_confounds <- list()
-          single_block_confounds[[block_name]] <- eyeris$confounds$unepoched_timeseries[[
+          single_block_confounds[[
             block_name
-          ]]
+          ]] <- eyeris$confounds$unepoched_timeseries[[block_name]]
 
           export_confounds_to_csv(
             confounds_list = single_block_confounds,
@@ -1200,7 +1234,9 @@ run_bidsify <- function(
         baseline_events_info <- get_baseline_events(eyeris, epoch_name, verbose)
         baseline_type_info <- get_baseline_type(eyeris, epoch_name, verbose)
 
-        for (block_name in names(eyeris$confounds$epoched_epoch_wide[[epoch_name]])) {
+        for (block_name in names(eyeris$confounds$epoched_epoch_wide[[
+          epoch_name
+        ]])) {
           block_confounds <- eyeris$confounds$epoched_epoch_wide[[epoch_name]][[
             block_name
           ]]
@@ -1212,7 +1248,9 @@ run_bidsify <- function(
           matched_events <- unique(block_confounds$matched_event)
 
           for (event in matched_events) {
-            event_confounds <- block_confounds[block_confounds$matched_event == event, ]
+            event_confounds <- block_confounds[
+              block_confounds$matched_event == event,
+            ]
 
             if (nrow(event_confounds) == 0) {
               next
@@ -1267,10 +1305,16 @@ run_bidsify <- function(
         }
 
         epoch_events_info <- if (
-          !is.null(find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name) &&
+          !is.null(
+            find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+          ) &&
             !is.null(
               eyeris[[
-                find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+                find_baseline_structure(
+                  eyeris,
+                  epoch_label,
+                  verbose
+                )$baseline_name
               ]]$block_1$info$epoch_events
             )
         ) {
@@ -1312,10 +1356,16 @@ run_bidsify <- function(
           NULL
         }
         baseline_events_info <- if (
-          !is.null(find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name) &&
+          !is.null(
+            find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+          ) &&
             !is.null(
               eyeris[[
-                find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+                find_baseline_structure(
+                  eyeris,
+                  epoch_label,
+                  verbose
+                )$baseline_name
               ]]$block_1$info$baseline_events
             )
         ) {
@@ -1335,10 +1385,16 @@ run_bidsify <- function(
           NULL
         }
         baseline_type_info <- if (
-          !is.null(find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name) &&
+          !is.null(
+            find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+          ) &&
             !is.null(
               eyeris[[
-                find_baseline_structure(eyeris, epoch_label, verbose)$baseline_name
+                find_baseline_structure(
+                  eyeris,
+                  epoch_label,
+                  verbose
+                )$baseline_name
               ]]$block_1$info$baseline_type
             )
         ) {
@@ -1358,7 +1414,9 @@ run_bidsify <- function(
           NULL
         }
 
-        for (block_name in names(eyeris$confounds$epoched_timeseries[[epoch_name]])) {
+        for (block_name in names(eyeris$confounds$epoched_timeseries[[
+          epoch_name
+        ]])) {
           block_confounds <- eyeris$confounds$epoched_timeseries[[epoch_name]][[
             block_name
           ]]
@@ -1370,7 +1428,9 @@ run_bidsify <- function(
           matched_events <- unique(block_confounds$matched_event)
 
           for (event in matched_events) {
-            event_confounds <- block_confounds[block_confounds$matched_event == event, ]
+            event_confounds <- block_confounds[
+              block_confounds$matched_event == event,
+            ]
 
             if (nrow(event_confounds) == 0) {
               next
@@ -1459,7 +1519,12 @@ run_bidsify <- function(
 
       for (i in seq_along(pupil_steps)) {
         for (p in seq_along(plot_types)) {
-          fig_name <- sprintf("run-%02d_fig-%d_desc-%s", run_dir_num, i, plot_types[p])
+          fig_name <- sprintf(
+            "run-%02d_fig-%d_desc-%s",
+            run_dir_num,
+            i,
+            plot_types[p]
+          )
           if (!is.null(eye_suffix)) {
             fig_name <- paste0(fig_name, "_", eye_suffix)
           }
@@ -1520,7 +1585,12 @@ run_bidsify <- function(
 
           fig_filename <- file.path(
             run_dir,
-            sprintf("run-%02d_fig-full-%d_desc-%s", run_dir_num, i_step, plot_types[p])
+            sprintf(
+              "run-%02d_fig-full-%d_desc-%s",
+              run_dir_num,
+              i_step,
+              plot_types[p]
+            )
           )
           if (!is.null(eye_suffix)) {
             fig_filename <- paste0(fig_filename, "_", eye_suffix)
@@ -1599,7 +1669,10 @@ run_bidsify <- function(
         run_dir <- file.path(figs_out, sprintf("run-%02d", run_dir_num))
         check_and_create_dir(run_dir, verbose = verbose)
 
-        heatmap_filename <- file.path(run_dir, sprintf("run-%02d_gaze_heatmap", i_run))
+        heatmap_filename <- file.path(
+          run_dir,
+          sprintf("run-%02d_gaze_heatmap", i_run)
+        )
 
         if (!is.null(eye_suffix)) {
           heatmap_filename <- paste0(heatmap_filename, "_", eye_suffix)
@@ -1695,7 +1768,10 @@ run_bidsify <- function(
               type = "n",
               xlab = "",
               ylab = "",
-              main = sprintf("Error creating binocular correlation for run-%02d", i_run)
+              main = sprintf(
+                "Error creating binocular correlation for run-%02d",
+                i_run
+              )
             )
             text(0.5, 0.5, paste("Error:", e$message), cex = 0.8, col = "red")
           }
@@ -1738,7 +1814,10 @@ run_bidsify <- function(
 
           tryCatch(
             {
-              check_column(epochs_to_save[[i]][[bn]], report_epoch_grouping_var_col)
+              check_column(
+                epochs_to_save[[i]][[bn]],
+                report_epoch_grouping_var_col
+              )
             },
             error = function(e) {
               error_handler(e, "column_doesnt_exist_in_df_error")
@@ -1877,7 +1956,9 @@ make_bids_fname <- function(
     )
   } else if (!is.null(epoch_events)) {
     # fallback: use epoch_events pattern if no epoch_name provided
-    epoch_event_name <- if (is.character(epoch_events) && length(epoch_events) == 1) {
+    epoch_event_name <- if (
+      is.character(epoch_events) && length(epoch_events) == 1
+    ) {
       gsub("[*{}]", "", epoch_events)
     } else {
       "multi_events"
@@ -1901,7 +1982,11 @@ make_bids_fname <- function(
     if (!is.null(baseline_type)) {
       bline_string <- paste0(bline_string, "-", baseline_type)
     }
-    bline_string <- paste0(bline_string, "-", sanitize_event_tag(baseline_event_name, ""))
+    bline_string <- paste0(
+      bline_string,
+      "-",
+      sanitize_event_tag(baseline_event_name, "")
+    )
     desc_parts <- c(desc_parts, bline_string)
   }
 
@@ -1953,7 +2038,10 @@ find_baseline_structure <- function(eyeris, epoch_label, verbose = TRUE) {
 
   for (baseline_name in baseline_names) {
     if (grepl(paste0("_epoch_", epoch_label, "$"), baseline_name)) {
-      log_info("Found matching baseline structure: {baseline_name}", verbose = verbose)
+      log_info(
+        "Found matching baseline structure: {baseline_name}",
+        verbose = verbose
+      )
       return(list(
         baseline_name = baseline_name,
         baseline_blocks = names(eyeris[[baseline_name]])
@@ -1968,9 +2056,18 @@ find_baseline_structure <- function(eyeris, epoch_label, verbose = TRUE) {
   NULL
 }
 
-get_epoch_info <- function(eyeris, epoch_id, block_name = "block_1", verbose = TRUE) {
+get_epoch_info <- function(
+  eyeris,
+  epoch_id,
+  block_name = "block_1",
+  verbose = TRUE
+) {
   epoch_label <- substr(epoch_id, 7, nchar(epoch_id))
-  baseline_structure_list <- find_baseline_structure(eyeris, epoch_label, verbose)
+  baseline_structure_list <- find_baseline_structure(
+    eyeris,
+    epoch_label,
+    verbose
+  )
 
   if (is.null(block_name)) {
     block_name <- baseline_structure_list$baseline_blocks[1]
@@ -1978,7 +2075,9 @@ get_epoch_info <- function(eyeris, epoch_id, block_name = "block_1", verbose = T
 
   if (
     !is.null(baseline_structure_list) &&
-      !is.null(eyeris[[baseline_structure_list$baseline_name]][[block_name]]$info)
+      !is.null(
+        eyeris[[baseline_structure_list$baseline_name]][[block_name]]$info
+      )
   ) {
     return(list(
       calc_baseline = eyeris[[baseline_structure_list$baseline_name]][[
@@ -2009,13 +2108,13 @@ get_epoch_info <- function(eyeris, epoch_id, block_name = "block_1", verbose = T
       ]]$info$epoch_events,
       epoch_limits = paste0(
         "(",
-        eyeris[[baseline_structure_list$baseline_name]][[block_name]]$info$epoch_limits[
-          1
-        ],
+        eyeris[[baseline_structure_list$baseline_name]][[
+          block_name
+        ]]$info$epoch_limits[1],
         ", ",
-        eyeris[[baseline_structure_list$baseline_name]][[block_name]]$info$epoch_limits[
-          2
-        ],
+        eyeris[[baseline_structure_list$baseline_name]][[
+          block_name
+        ]]$info$epoch_limits[2],
         ")"
       ),
       n_epochs = eyeris[[baseline_structure_list$baseline_name]][[
@@ -2066,13 +2165,21 @@ format_event_string <- function(events) {
   }
 }
 
-get_epoch_events <- function(eyeris, epoch_id, block_name = "block_1", verbose = TRUE) {
+get_epoch_events <- function(
+  eyeris,
+  epoch_id,
+  block_name = "block_1",
+  verbose = TRUE
+) {
   info <- get_epoch_info(eyeris, epoch_id, block_name, verbose)
   if (!is.null(info) && !is.null(info$epoch_events)) {
     result <- format_event_string(info$epoch_events)
     if (!is.null(result)) {
       escaped_result <- gsub("\\{", "{{", gsub("\\}", "}}", result))
-      log_info("Found epoch events in structure: {escaped_result}", verbose = verbose)
+      log_info(
+        "Found epoch events in structure: {escaped_result}",
+        verbose = verbose
+      )
       return(result)
     }
   }
@@ -2096,7 +2203,12 @@ get_baseline_events <- function(
   return(NULL)
 }
 
-get_baseline_type <- function(eyeris, epoch_id, block_name = "block_1", verbose = TRUE) {
+get_baseline_type <- function(
+  eyeris,
+  epoch_id,
+  block_name = "block_1",
+  verbose = TRUE
+) {
   info <- get_epoch_info(eyeris, epoch_id, block_name, verbose)
   if (!is.null(info) && !is.na(info$baseline_type)) {
     result <- format_event_string(info$baseline_type)

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1949,7 +1949,6 @@ run_bidsify <- function(
     )
 
     render_report(report_output)
-    
     # zip and cleanup figures directories after report generation
     cleanup_source_figures_post_render(
       report_path = report_path,

--- a/R/pipeline-bin.R
+++ b/R/pipeline-bin.R
@@ -168,7 +168,10 @@ bin_pupil <- function(x, prev_op, bins_per_second, method, current_fs) {
   bin_centers <- seq(min_time + bin_duration / 2, max_time, by = bin_duration)
 
   # pre-compute bin assignments for all time points
-  bin_assignments <- findInterval(time_secs_inferred, bin_centers - bin_duration / 2)
+  bin_assignments <- findInterval(
+    time_secs_inferred,
+    bin_centers - bin_duration / 2
+  )
 
   binned_df <- data.frame(time_secs = bin_centers, stringsAsFactors = FALSE)
 
@@ -200,7 +203,10 @@ bin_pupil <- function(x, prev_op, bins_per_second, method, current_fs) {
   }
 
   binned_bin_col <- bin_vector(prev_pupil, bin_assignments, bin_centers, method)
-  binned_df <- cbind(binned_df, setNames(list(binned_bin_col), paste0(prev_op, "_bin")))
+  binned_df <- cbind(
+    binned_df,
+    setNames(list(binned_bin_col), paste0(prev_op, "_bin"))
+  )
 
   # process all remaining cols from the orig df
   cols_to_process <- 0
@@ -219,7 +225,12 @@ bin_pupil <- function(x, prev_op, bins_per_second, method, current_fs) {
   for (col in names(x)) {
     if (col != prev_op && col != time_col && !grepl("_bin$", col)) {
       if (is.numeric(x[[col]])) {
-        binned_df[[col]] <- bin_vector(x[[col]], bin_assignments, bin_centers, method)
+        binned_df[[col]] <- bin_vector(
+          x[[col]],
+          bin_assignments,
+          bin_centers,
+          method
+        )
       } else {
         binned_df[[col]] <- sapply(seq_along(bin_centers), function(i) {
           bin_indices <- which(bin_assignments == i)
@@ -234,5 +245,8 @@ bin_pupil <- function(x, prev_op, bins_per_second, method, current_fs) {
     }
   }
 
-  list_out <- list(downsampled_df = binned_df, decimated.sample.rate = bins_per_second)
+  list_out <- list(
+    downsampled_df = binned_df,
+    decimated.sample.rate = bins_per_second
+  )
 }

--- a/R/pipeline-confounds.R
+++ b/R/pipeline-confounds.R
@@ -111,7 +111,12 @@ summarize_confounds <- function(eyeris) {
   epoch_names <- grep("^epoch_", names(eyeris), value = TRUE)
 
   if (length(epoch_names) > 0) {
-    eyeris <- calculate_epoched_confounds(eyeris, epoch_names, hz, verbose = TRUE)
+    eyeris <- calculate_epoched_confounds(
+      eyeris,
+      epoch_names,
+      hz,
+      verbose = TRUE
+    )
   }
 
   eyeris
@@ -138,7 +143,13 @@ summarize_confounds <- function(eyeris) {
 #' @return A data frame containing confounds metrics for the current step
 #'
 #' @keywords internal
-get_confounds_for_step <- function(pupil_df, pupil_vec, screen_width, screen_height, hz) {
+get_confounds_for_step <- function(
+  pupil_df,
+  pupil_vec,
+  screen_width,
+  screen_height,
+  hz
+) {
   if (!("is_blink" %in% names(pupil_df))) {
     pupil_df <- tag_blinks(pupil_df, pupil_vec)
   }
@@ -179,11 +190,23 @@ get_confounds_for_step <- function(pupil_df, pupil_vec, screen_width, screen_hei
     prop_invalid = mean(is_invalid),
     n_gaps = length(gap_lengths),
     max_gap_n_samples = if (length(gap_lengths)) max(gap_lengths) else 0,
-    max_gap_duration_ms = if (length(gap_lengths)) max(gap_lengths) / hz * 1000 else 0,
+    max_gap_duration_ms = if (length(gap_lengths)) {
+      max(gap_lengths) / hz * 1000
+    } else {
+      0
+    },
     min_gap_n_samples = if (length(gap_lengths)) min(gap_lengths) else 0,
-    min_gap_duration_ms = if (length(gap_lengths)) min(gap_lengths) / hz * 1000 else 0,
+    min_gap_duration_ms = if (length(gap_lengths)) {
+      min(gap_lengths) / hz * 1000
+    } else {
+      0
+    },
     mean_gap_n_samples = if (length(gap_lengths)) mean(gap_lengths) else 0,
-    mean_gap_duration_ms = if (length(gap_lengths)) mean(gap_lengths) / hz * 1000 else 0,
+    mean_gap_duration_ms = if (length(gap_lengths)) {
+      mean(gap_lengths) / hz * 1000
+    } else {
+      0
+    },
     screen_width = screen_width,
     screen_height = screen_height,
     gaze_x_var_px = var(pupil_df$eye_x, na.rm = TRUE),
@@ -474,12 +497,27 @@ export_confounds_to_csv <- function(
 #' @return An updated `eyeris` object with epoched confounds
 #'
 #' @keywords internal
-calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE) {
+calculate_epoched_confounds <- function(
+  eyeris,
+  epoch_names,
+  hz,
+  verbose = TRUE
+) {
   # handle binocular objects
   if (is_binocular_object(eyeris)) {
     # process left and right eyes independently
-    left_result <- calculate_epoched_confounds(eyeris$left, epoch_names, hz, verbose)
-    right_result <- calculate_epoched_confounds(eyeris$right, epoch_names, hz, verbose)
+    left_result <- calculate_epoched_confounds(
+      eyeris$left,
+      epoch_names,
+      hz,
+      verbose
+    )
+    right_result <- calculate_epoched_confounds(
+      eyeris$right,
+      epoch_names,
+      hz,
+      verbose
+    )
 
     # return combined structure
     list_out <- list(
@@ -508,7 +546,11 @@ calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE)
 
       epoch_data <- eyeris[[epoch_name]][[block_name]]
 
-      if (is.null(epoch_data) || !is.data.frame(epoch_data) || nrow(epoch_data) == 0) {
+      if (
+        is.null(epoch_data) ||
+          !is.data.frame(epoch_data) ||
+          nrow(epoch_data) == 0
+      ) {
         next
       }
 
@@ -544,10 +586,13 @@ calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE)
         if ("baseline_period" %in% names(epoch_subset)) {
           baseline_start <- min(epoch_subset$baseline_period)
           baseline_end <- max(epoch_subset$baseline_period)
-          n_blinks_baseline <- sum(sapply(seq_len(nrow(block_blinks)), function(i) {
-            max(block_blinks$stime[i], baseline_start) <=
-              min(block_blinks$etime[i], baseline_end)
-          }))
+          n_blinks_baseline <- sum(sapply(
+            seq_len(nrow(block_blinks)),
+            function(i) {
+              max(block_blinks$stime[i], baseline_start) <=
+                min(block_blinks$etime[i], baseline_end)
+            }
+          ))
         }
         first_blink_time <- NA
         epoch_start_time <- min(epoch_subset$time_orig)
@@ -556,7 +601,9 @@ calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE)
             block_blinks$stime <= max(epoch_subset$time_orig),
         ]
         if (nrow(blinks_in_epoch) > 0) {
-          first_blink_time <- (min(blinks_in_epoch$stime) - epoch_start_time) / hz * 1000
+          first_blink_time <- (min(blinks_in_epoch$stime) - epoch_start_time) /
+            hz *
+            1000
         }
 
         epoch_wide_confounds[[as.character(id)]] <- data.frame(
@@ -591,7 +638,8 @@ calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE)
           pre_epoch_window <- c(epoch_start_time - 200, epoch_start_time)
           pre_epoch_data <- eyeris$timeseries[[block_name]] |>
             dplyr::filter(
-              time_orig >= pre_epoch_window[1] & time_orig <= pre_epoch_window[2]
+              time_orig >= pre_epoch_window[1] &
+                time_orig <= pre_epoch_window[2]
             )
 
           step_df <- data.frame(
@@ -622,17 +670,15 @@ calculate_epoched_confounds <- function(eyeris, epoch_names, hz, verbose = TRUE)
       }
 
       if (length(epoch_wide_confounds) > 0) {
-        eyeris$confounds$epoched_epoch_wide[[epoch_name]][[block_name]] <- do.call(
-          rbind,
-          epoch_wide_confounds
-        )
+        eyeris$confounds$epoched_epoch_wide[[epoch_name]][[
+          block_name
+        ]] <- do.call(rbind, epoch_wide_confounds)
       }
 
       if (length(step_specific_confounds) > 0) {
-        eyeris$confounds$epoched_timeseries[[epoch_name]][[block_name]] <- do.call(
-          rbind,
-          step_specific_confounds
-        )
+        eyeris$confounds$epoched_timeseries[[epoch_name]][[
+          block_name
+        ]] <- do.call(rbind, step_specific_confounds)
       }
     }
   }

--- a/R/pipeline-deblink.R
+++ b/R/pipeline-deblink.R
@@ -63,10 +63,20 @@ deblink <- function(eyeris, extend = 50, call_info = NULL) {
   if (is_binocular_object(eyeris)) {
     # process left and right eyes independently
     left_result <- eyeris$left |>
-      pipeline_handler(deblink_pupil, "deblink", extend = extend, call_info = call_info)
+      pipeline_handler(
+        deblink_pupil,
+        "deblink",
+        extend = extend,
+        call_info = call_info
+      )
 
     right_result <- eyeris$right |>
-      pipeline_handler(deblink_pupil, "deblink", extend = extend, call_info = call_info)
+      pipeline_handler(
+        deblink_pupil,
+        "deblink",
+        extend = extend,
+        call_info = call_info
+      )
 
     # return combined structure
     list_out <- list(
@@ -82,7 +92,12 @@ deblink <- function(eyeris, extend = 50, call_info = NULL) {
   } else {
     # regular eyeris object, process normally
     eyeris |>
-      pipeline_handler(deblink_pupil, "deblink", extend = extend, call_info = call_info)
+      pipeline_handler(
+        deblink_pupil,
+        "deblink",
+        extend = extend,
+        call_info = call_info
+      )
   }
 }
 
@@ -155,12 +170,16 @@ deblink_pupil <- function(x, prev_op, extend) {
       ),
       blink.end = zoo::na.locf(blink.end, na.rm = FALSE),
       blink = ifelse(
-        !is.na(blink.start) & time >= blink.start - extend_backward & time <= blink.start,
+        !is.na(blink.start) &
+          time >= blink.start - extend_backward &
+          time <= blink.start,
         1,
         blink
       ),
       blink = ifelse(
-        !is.na(blink.end) & time <= blink.end + extend_forward & time >= blink.end,
+        !is.na(blink.end) &
+          time <= blink.end + extend_forward &
+          time >= blink.end,
         1,
         blink
       ),

--- a/R/pipeline-detransient.R
+++ b/R/pipeline-detransient.R
@@ -99,7 +99,10 @@
 #' @export
 detransient <- function(eyeris, n = 16, mad_thresh = NULL, call_info = NULL) {
   call_info <- if (is.null(call_info)) {
-    list(call_stack = match.call(), parameters = list(n = n, mad_thresh = mad_thresh))
+    list(
+      call_stack = match.call(),
+      parameters = list(n = n, mad_thresh = mad_thresh)
+    )
   } else {
     call_info
   }

--- a/R/pipeline-detrend.R
+++ b/R/pipeline-detrend.R
@@ -101,5 +101,9 @@ detrend_pupil <- function(x, prev_op) {
   coefficients <- fit$coefficients
   residuals <- fit$residuals
 
-  list(fitted_values = fitted_values, coefficients = coefficients, residuals = residuals)
+  list(
+    fitted_values = fitted_values,
+    coefficients = coefficients,
+    residuals = residuals
+  )
 }

--- a/R/pipeline-downsample.R
+++ b/R/pipeline-downsample.R
@@ -60,7 +60,12 @@ downsample <- function(
   call_info <- if (is.null(call_info)) {
     list(
       call_stack = match.call(),
-      parameters = list(target_fs = target_fs, plot_freqz = plot_freqz, rp = rp, rs = rs)
+      parameters = list(
+        target_fs = target_fs,
+        plot_freqz = plot_freqz,
+        rp = rp,
+        rs = rs
+      )
     )
   } else {
     call_info
@@ -141,7 +146,15 @@ downsample <- function(
 #' @return A list containing the downsampled data and the decimated sample rate
 #'
 #' @keywords internal
-downsample_pupil <- function(x, prev_op, target_fs, plot_freqz, current_fs, rp, rs) {
+downsample_pupil <- function(
+  x,
+  prev_op,
+  target_fs,
+  plot_freqz,
+  current_fs,
+  rp,
+  rs
+) {
   if (any(is.na(x[[prev_op]]))) {
     log_error("NAs detected in pupil data. Need to interpolate first.")
     return(x[[prev_op]])
@@ -204,7 +217,14 @@ downsample_pupil <- function(x, prev_op, target_fs, plot_freqz, current_fs, rp, 
     plot_width <- par("pin")[1]
     scaling_factor <- 7
     cex_val <- plot_width / scaling_factor
-    graphics::mtext(side = 2, line = 2, at = 0, adj = 0.95, cex = cex_val, subtitle)
+    graphics::mtext(
+      side = 2,
+      line = 2,
+      at = 0,
+      adj = 0.95,
+      cex = cex_val,
+      subtitle
+    )
   }
 
   # apply anti-aliasing filter
@@ -217,5 +237,8 @@ downsample_pupil <- function(x, prev_op, target_fs, plot_freqz, current_fs, rp, 
   downsampled_df <- x[indices, , drop = FALSE]
   downsampled_df[[paste0(prev_op, "_downsample")]] <- downsampled_data
 
-  list_out <- list(downsampled_df = downsampled_df, decimated.sample.rate = target_fs)
+  list_out <- list(
+    downsampled_df = downsampled_df,
+    decimated.sample.rate = target_fs
+  )
 }

--- a/R/pipeline-epoch.R
+++ b/R/pipeline-epoch.R
@@ -220,14 +220,22 @@ epoch <- function(
 ) {
   # handle deprecated parameters
   if (is_present(calc_baseline)) {
-    lifecycle::deprecate_warn("1.3.0", "epoch(calc_baseline)", "epoch(baseline)")
+    lifecycle::deprecate_warn(
+      "1.3.0",
+      "epoch(calc_baseline)",
+      "epoch(baseline)"
+    )
     if (isTRUE(calc_baseline)) {
       baseline <- TRUE
     }
   }
 
   if (is_present(apply_baseline)) {
-    lifecycle::deprecate_warn("1.3.0", "epoch(apply_baseline)", "epoch(baseline)")
+    lifecycle::deprecate_warn(
+      "1.3.0",
+      "epoch(apply_baseline)",
+      "epoch(baseline)"
+    )
     if (isTRUE(apply_baseline)) {
       baseline <- TRUE
     }
@@ -412,7 +420,11 @@ epoch_pupil <- function(
     block_int <- get_block_numbers(bn)
 
     if (!is.list(evs)) {
-      n_events <- merge_events_with_timeseries(x$events[[bn]], msg_s, merge = FALSE) |>
+      n_events <- merge_events_with_timeseries(
+        x$events[[bn]],
+        msg_s,
+        merge = FALSE
+      ) |>
         nrow()
 
       log_info(
@@ -501,7 +513,10 @@ epoch_pupil <- function(
 
   # recalculate epoched confounds if they exist, since new epochs were created
   if (!is.null(x$confounds$unepoched_timeseries)) {
-    log_info("Recalculating epoched confounds for new epochs...", verbose = verbose)
+    log_info(
+      "Recalculating epoched confounds for new epochs...",
+      verbose = verbose
+    )
 
     # check for epoch data and compute confounds if present
     epoch_names <- grep("^epoch_", names(x), value = TRUE)
@@ -576,7 +591,9 @@ epoch_and_baseline_block <- function(
   dt <- data.table::as.data.table(block_data)
 
   if (!"time_orig" %in% names(dt)) {
-    log_error("Block '{block_name}' doesn't contain the expected `time_orig` column.")
+    log_error(
+      "Block '{block_name}' doesn't contain the expected `time_orig` column."
+    )
   }
 
   data.table::setkey(dt, "time_orig")
@@ -696,11 +713,21 @@ epoch_and_baseline_block <- function(
 #' @return A list containing epoch and baseline results
 #'
 #' @keywords internal
-process_epoch_and_baselines <- function(eyeris, timestamps, evs, lims, hz, verbose) {
+process_epoch_and_baselines <- function(
+  eyeris,
+  timestamps,
+  evs,
+  lims,
+  hz,
+  verbose
+) {
   n_timestamps <- nrow(timestamps$start)
 
   if (n_timestamps == 0 && !is.null(n_timestamps)) {
-    log_info("* No timestamps to process in this block... skipping.", verbose = verbose)
+    log_info(
+      "* No timestamps to process in this block... skipping.",
+      verbose = verbose
+    )
 
     return(list())
   }
@@ -711,15 +738,21 @@ process_epoch_and_baselines <- function(eyeris, timestamps, evs, lims, hz, verbo
     if (is.null(lims)) {
       epochs <- eyeris |> epoch_only_start_msg(timestamps$start, hz, verbose)
     } else {
-      epochs <- eyeris |> epoch_start_msg_and_limits(timestamps$start, lims, hz, verbose)
+      epochs <- eyeris |>
+        epoch_start_msg_and_limits(timestamps$start, lims, hz, verbose)
     }
   } else if (is.character(evs) && length(evs) == 2) {
-    epochs <- eyeris |> epoch_start_end_msg(timestamps$start, timestamps$end, hz, verbose)
+    epochs <- eyeris |>
+      epoch_start_end_msg(timestamps$start, timestamps$end, hz, verbose)
   } else if (is.list(evs)) {
     epochs <- eyeris |> epoch_manually(evs, hz, verbose)
   }
 
-  if (!is.null(n_timestamps) && length(epochs) > 0 && length(epochs) != n_timestamps) {
+  if (
+    !is.null(n_timestamps) &&
+      length(epochs) > 0 &&
+      length(epochs) != n_timestamps
+  ) {
     log_error(
       "Expected {n_timestamps} samples but got {length(epochs)} samples. Check data for a possible matching error."
     )
@@ -773,7 +806,9 @@ epoch_manually <- function(eyeris, ts_list, hz, verbose) {
     i_start <- s_df$time[i]
     i_end <- e_df$time[i]
 
-    current_epoch <- eyeris |> purrr::pluck("timeseries") |> slice_epoch(i_start, i_end)
+    current_epoch <- eyeris |>
+      purrr::pluck("timeseries") |>
+      slice_epoch(i_start, i_end)
 
     duration <- nrow(current_epoch) / hz
     n_samples <- duration * hz
@@ -781,7 +816,10 @@ epoch_manually <- function(eyeris, ts_list, hz, verbose) {
     start_metadata_vals <- dplyr::rename_with(s_df, ~ paste0("start_", .x))
     end_metadata_vals <- dplyr::rename_with(e_df, ~ paste0("end_", .x))
 
-    metadata_vals <- dplyr::bind_cols(start_metadata_vals[i, ], end_metadata_vals[i, ])
+    metadata_vals <- dplyr::bind_cols(
+      start_metadata_vals[i, ],
+      end_metadata_vals[i, ]
+    )
 
     epochs[[i]] <- current_epoch |>
       dplyr::mutate(timebin = seq(0, duration, length.out = n_samples)) |>
@@ -924,7 +962,10 @@ epoch_start_end_msg <- function(eyeris, start, end, hz, verbose) {
       ~ paste0("start_", .x)
     )
 
-    end_metadata_vals <- dplyr::rename_with(index_metadata(end, i), ~ paste0("end_", .x))
+    end_metadata_vals <- dplyr::rename_with(
+      index_metadata(end, i),
+      ~ paste0("end_", .x)
+    )
 
     metadata_vals <- start_metadata_vals |> dplyr::bind_cols(end_metadata_vals)
 

--- a/R/pipeline-glassbox.R
+++ b/R/pipeline-glassbox.R
@@ -131,7 +131,11 @@ glassbox <- function(
 
   # handle deprecated parameters
   if (is_present(confirm)) {
-    deprecate_warn("1.1.0", "glassbox(confirm)", "glassbox(interactive_preview)")
+    deprecate_warn(
+      "1.1.0",
+      "glassbox(confirm)",
+      "glassbox(interactive_preview)"
+    )
     interactive_preview <- confirm
   }
 
@@ -184,7 +188,12 @@ glassbox <- function(
   params <- utils::modifyList(default_params, list(...))
 
   # handle method parameter for bin operation
-  if ("method" %in% names(list(...)) && !is.null(params$bin) && is.list(params$bin)) {
+  if (
+    "method" %in%
+      names(list(...)) &&
+      !is.null(params$bin) &&
+      is.list(params$bin)
+  ) {
     params$bin$method <- list(...)$method
   }
 
@@ -299,7 +308,11 @@ glassbox <- function(
           call = original_call,
           parameters = list(extend = params$deblink$extend)
         )
-        eyeris::deblink(data, extend = params$deblink$extend, call_info = call_info)
+        eyeris::deblink(
+          data,
+          extend = params$deblink$extend,
+          call_info = call_info
+        )
       } else {
         data
       }
@@ -325,7 +338,10 @@ glassbox <- function(
     },
     interpolate = function(data, params, original_call) {
       if (which_steps[["interpolate"]]) {
-        call_info <- list(call = original_call, parameters = list(verbose = verbose))
+        call_info <- list(
+          call = original_call,
+          parameters = list(verbose = verbose)
+        )
         eyeris::interpolate(data, verbose = verbose, call_info = call_info)
       } else {
         data
@@ -554,7 +570,11 @@ glassbox <- function(
           skip_plot <- TRUE
 
           if (!is.null(temp_file$latest[[block_name]])) {
-            expected_col <- paste0(temp_file$latest[[block_name]], "_", step_name)
+            expected_col <- paste0(
+              temp_file$latest[[block_name]],
+              "_",
+              step_name
+            )
             block_data <- temp_file$timeseries[[block_name]]
             if (expected_col %in% colnames(block_data)) {
               temp_file$latest[[block_name]] <- expected_col
@@ -567,9 +587,15 @@ glassbox <- function(
         }
 
         if (action == "Running ") {
-          log_success("{action}eyeris::{step_name}() for {block_name}", verbose = verbose)
+          log_success(
+            "{action}eyeris::{step_name}() for {block_name}",
+            verbose = verbose
+          )
         } else {
-          log_warn("Skipping eyeris::{step_name}() for {block_name}", verbose = verbose)
+          log_warn(
+            "Skipping eyeris::{step_name}() for {block_name}",
+            verbose = verbose
+          )
         }
 
         step_to_run <- pipeline[[step_name]]
@@ -604,7 +630,9 @@ glassbox <- function(
             if (length(pupil_cols) > 0) {
               # use last valid pupil column
               temp_file$latest[[block_name]] <- pupil_cols[length(pupil_cols)]
-              block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+              block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+                block_name
+              ]]
             } else {
               # fallback to original pointer for this block
               if (is.list(original_latest)) {
@@ -612,7 +640,9 @@ glassbox <- function(
               } else {
                 temp_file$latest[[block_name]] <- original_latest
               }
-              block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+              block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+                block_name
+              ]]
             }
 
             temp_file
@@ -690,7 +720,9 @@ glassbox <- function(
       }
 
       # update block state with final state
-      block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+      block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+        block_name
+      ]]
       block_states[[block_name]]$steps_completed <- block_step_counter - 1
 
       # update main file's latest pointer for current block
@@ -889,7 +921,11 @@ glassbox_internal <- function(
           call = original_call,
           parameters = list(extend = params$deblink$extend)
         )
-        eyeris::deblink(data, extend = params$deblink$extend, call_info = call_info)
+        eyeris::deblink(
+          data,
+          extend = params$deblink$extend,
+          call_info = call_info
+        )
       } else {
         data
       }
@@ -915,7 +951,10 @@ glassbox_internal <- function(
     },
     interpolate = function(data, params, original_call) {
       if (which_steps[["interpolate"]]) {
-        call_info <- list(call = original_call, parameters = list(verbose = verbose))
+        call_info <- list(
+          call = original_call,
+          parameters = list(verbose = verbose)
+        )
         eyeris::interpolate(data, verbose = verbose, call_info = call_info)
       } else {
         data
@@ -1070,7 +1109,11 @@ glassbox_internal <- function(
           skip_plot <- TRUE
 
           if (!is.null(temp_file$latest[[block_name]])) {
-            expected_col <- paste0(temp_file$latest[[block_name]], "_", step_name)
+            expected_col <- paste0(
+              temp_file$latest[[block_name]],
+              "_",
+              step_name
+            )
             block_data <- temp_file$timeseries[[block_name]]
             if (expected_col %in% colnames(block_data)) {
               temp_file$latest[[block_name]] <- expected_col
@@ -1083,9 +1126,15 @@ glassbox_internal <- function(
         }
 
         if (action == "Running ") {
-          log_success("{action}eyeris::{step_name}() for {block_name}", verbose = verbose)
+          log_success(
+            "{action}eyeris::{step_name}() for {block_name}",
+            verbose = verbose
+          )
         } else {
-          log_warn("Skipping eyeris::{step_name}() for {block_name}", verbose = verbose)
+          log_warn(
+            "Skipping eyeris::{step_name}() for {block_name}",
+            verbose = verbose
+          )
         }
         step_to_run <- pipeline[[step_name]]
         err_thrown <- FALSE
@@ -1119,7 +1168,9 @@ glassbox_internal <- function(
             if (length(pupil_cols) > 0) {
               # use last valid pupil column
               temp_file$latest[[block_name]] <- pupil_cols[length(pupil_cols)]
-              block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+              block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+                block_name
+              ]]
             } else {
               # fallback to original pointer for this block
               if (is.list(original_latest)) {
@@ -1127,7 +1178,9 @@ glassbox_internal <- function(
               } else {
                 temp_file$latest[[block_name]] <- original_latest
               }
-              block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+              block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+                block_name
+              ]]
             }
 
             temp_file
@@ -1205,7 +1258,9 @@ glassbox_internal <- function(
       }
 
       # update block state with final state
-      block_states[[block_name]]$latest_pointer <- temp_file$latest[[block_name]]
+      block_states[[block_name]]$latest_pointer <- temp_file$latest[[
+        block_name
+      ]]
       block_states[[block_name]]$steps_completed <- block_step_counter - 1
 
       # update main file's latest pointer for current block

--- a/R/pipeline-handler.R
+++ b/R/pipeline-handler.R
@@ -156,7 +156,11 @@ pipeline_handler <- function(eyeris, operation, new_suffix, ...) {
   if (is.list(eyeris$timeseries) && !is.data.frame(eyeris$timeseries)) {
     is_multiblock <- TRUE
   } else {
-    if (is.null(prev_operation) || length(prev_operation) == 0 || prev_operation == "") {
+    if (
+      is.null(prev_operation) ||
+        length(prev_operation) == 0 ||
+        prev_operation == ""
+    ) {
       log_error(
         "Latest pointer is empty or NULL. This indicates a pipeline initialization error."
       )
@@ -216,7 +220,10 @@ pipeline_handler <- function(eyeris, operation, new_suffix, ...) {
           )
         }
         if (new_suffix == "detrend") {
-          list_detrend <- do.call(operation, c(list(data, block_prev_operation), dots))
+          list_detrend <- do.call(
+            operation,
+            c(list(data, block_prev_operation), dots)
+          )
           data["detrend_fitted_values"] <- list_detrend$fitted_values
           data[[block_output_col]] <- list_detrend$residuals
           if (!exists("detrend_coefs", eyeris)) {
@@ -224,7 +231,10 @@ pipeline_handler <- function(eyeris, operation, new_suffix, ...) {
           }
           eyeris$detrend_coefs[[i_block]] <- list_detrend$coefficients
         } else if (new_suffix == "bin" || new_suffix == "downsample") {
-          list_ds_bin <- do.call(operation, c(list(data, block_prev_operation), dots))
+          list_ds_bin <- do.call(
+            operation,
+            c(list(data, block_prev_operation), dots)
+          )
           data <- list_ds_bin$downsampled_df |>
             dplyr::select(
               block,
@@ -248,7 +258,9 @@ pipeline_handler <- function(eyeris, operation, new_suffix, ...) {
         }
       }
     }
-    if (new_suffix != "bin" && new_suffix != "downsample" && new_suffix != "epoch") {
+    if (
+      new_suffix != "bin" && new_suffix != "downsample" && new_suffix != "epoch"
+    ) {
       for (i_block in names(eyeris$timeseries)) {
         block_prev_operation <- eyeris$latest[[i_block]]
         block_output_col <- paste0(block_prev_operation, "_", new_suffix)
@@ -277,7 +289,10 @@ pipeline_handler <- function(eyeris, operation, new_suffix, ...) {
         data["detrend_fitted_values"] <- list_detrend$fitted_values
         data[[output_col]] <- list_detrend$residuals
       } else {
-        data[[output_col]] <- do.call(operation, c(list(data, prev_operation), dots))
+        data[[output_col]] <- do.call(
+          operation,
+          c(list(data, prev_operation), dots)
+        )
       }
       eyeris$timeseries <- data
       if (new_suffix == "detrend") {

--- a/R/pipeline-interpolate.R
+++ b/R/pipeline-interpolate.R
@@ -55,10 +55,20 @@ interpolate <- function(eyeris, verbose = TRUE, call_info = NULL) {
   if (is_binocular_object(eyeris)) {
     # process left and right eyes independently
     left_result <- eyeris$left |>
-      pipeline_handler(interpolate_pupil, "interpolate", verbose, call_info = call_info)
+      pipeline_handler(
+        interpolate_pupil,
+        "interpolate",
+        verbose,
+        call_info = call_info
+      )
 
     right_result <- eyeris$right |>
-      pipeline_handler(interpolate_pupil, "interpolate", verbose, call_info = call_info)
+      pipeline_handler(
+        interpolate_pupil,
+        "interpolate",
+        verbose,
+        call_info = call_info
+      )
 
     # return combined structure
     list_out <- list(
@@ -74,7 +84,12 @@ interpolate <- function(eyeris, verbose = TRUE, call_info = NULL) {
   } else {
     # regular eyeris object, process normally
     eyeris |>
-      pipeline_handler(interpolate_pupil, "interpolate", verbose, call_info = call_info)
+      pipeline_handler(
+        interpolate_pupil,
+        "interpolate",
+        verbose,
+        call_info = call_info
+      )
   }
 }
 

--- a/R/pipeline-loadasc.R
+++ b/R/pipeline-loadasc.R
@@ -103,7 +103,12 @@ load_asc <- function(
     log_error("Error: The file '{file}' is not a .asc file.")
   }
 
-  x <- eyelinker::read.asc(fname = file, samples = TRUE, events = TRUE, parse_all = FALSE)
+  x <- eyelinker::read.asc(
+    fname = file,
+    samples = TRUE,
+    events = TRUE,
+    parse_all = FALSE
+  )
 
   # parse metadata
   is_mono <- x$info$mono
@@ -219,7 +224,10 @@ load_asc <- function(
       x$raw$ypl <- NULL
       x$raw$ypr <- NULL
     } else if (binocular_mode == "both") {
-      list_out$raw_binocular_object <- list(left = left_eyeris, right = right_eyeris)
+      list_out$raw_binocular_object <- list(
+        left = left_eyeris,
+        right = right_eyeris
+      )
       return(list_out)
     }
 
@@ -269,7 +277,16 @@ load_asc <- function(
 #' @return An `eyeris` object
 #'
 #' @keywords internal
-process_eyeris_data <- function(x, block, eye, hz, pupil_type, file, binoc, binoc_mode) {
+process_eyeris_data <- function(
+  x,
+  block,
+  eye,
+  hz,
+  pupil_type,
+  file,
+  binoc,
+  binoc_mode
+) {
   # raw data processing
   if (eye == "left") {
     eye_meta <- "L"
@@ -280,7 +297,13 @@ process_eyeris_data <- function(x, block, eye, hz, pupil_type, file, binoc, bino
   }
 
   raw_df <- x$raw |>
-    dplyr::select(block, time_orig = time, pupil_raw = ps, eye_x = xp, eye_y = yp) |>
+    dplyr::select(
+      block,
+      time_orig = time,
+      pupil_raw = ps,
+      eye_x = xp,
+      eye_y = yp
+    ) |>
     dplyr::mutate(eye = eye_meta, hz = hz, type = pupil_type) |>
     dplyr::relocate(pupil_raw, .after = type)
 
@@ -336,7 +359,8 @@ process_eyeris_data <- function(x, block, eye, hz, pupil_type, file, binoc, bino
     list_out$timeseries <- list("block_1" = raw_df)
 
     # omit the block column from the time series, events, and blinks
-    list_out$timeseries$block_1 <- list_out$timeseries$block_1 |> dplyr::select(-block)
+    list_out$timeseries$block_1 <- list_out$timeseries$block_1 |>
+      dplyr::select(-block)
     list_out$events <- x$msg |> dplyr::select(-block)
     list_out$blinks <- x$blinks |> dplyr::select(-block)
   }

--- a/R/pipeline-lpfilt.R
+++ b/R/pipeline-lpfilt.R
@@ -66,7 +66,13 @@ lpfilt <- function(
   call_info <- if (is.null(call_info)) {
     list(
       call_stack = match.call(),
-      parameters = list(wp = wp, ws = ws, rp = rp, rs = rs, plot_freqz = plot_freqz)
+      parameters = list(
+        wp = wp,
+        ws = ws,
+        rp = rp,
+        rs = rs,
+        plot_freqz = plot_freqz
+      )
     )
   } else {
     call_info
@@ -162,7 +168,9 @@ lpfilt_pupil <- function(x, prev_op, wp, ws, rp, rs, fs, plot_freqz) {
   }
 
   if (any(!is.finite(prev_pupil))) {
-    log_error("Non-finite values detected in pupil data. Need to clean data first.")
+    log_error(
+      "Non-finite values detected in pupil data. Need to clean data first."
+    )
   }
 
   # design a Butterworth filter with minimum order to meet requirements
@@ -189,7 +197,14 @@ lpfilt_pupil <- function(x, prev_op, wp, ws, rp, rs, fs, plot_freqz) {
     plot_width <- par("pin")[1]
     scaling_factor <- 7
     cex_val <- plot_width / scaling_factor
-    graphics::mtext(side = 2, line = 2, at = 0, adj = 0.95, cex = cex_val, subtitle)
+    graphics::mtext(
+      side = 2,
+      line = 2,
+      at = 0,
+      adj = 0.95,
+      cex = cex_val,
+      subtitle
+    )
   }
 
   # filter twice (forward and backward) to preserve phase information

--- a/R/plot.eyeris.R
+++ b/R/plot.eyeris.R
@@ -277,7 +277,12 @@ plot.eyeris <- function(
 
   if (is.null(preview_window)) {
     withr::with_seed(seed, {
-      random_epochs <- draw_random_epochs(pupil_data, preview_n, preview_duration, hz)
+      random_epochs <- draw_random_epochs(
+        pupil_data,
+        preview_n,
+        preview_duration,
+        hz
+      )
     })
 
     par(mfrow = c(1, preview_n), oma = c(0, 0, 3, 0))
@@ -345,7 +350,9 @@ plot.eyeris <- function(
         }
 
         if (!is.null(params$next_step)) {
-          plot_data <- random_epochs[[n]][[params$next_step[length(params$next_step)]]]
+          plot_data <- random_epochs[[n]][[params$next_step[length(
+            params$next_step
+          )]]]
         } else {
           plot_data <- random_epochs[[n]][[pupil_steps[i]]]
         }
@@ -419,13 +426,16 @@ plot.eyeris <- function(
         end_index > nrow(pupil_data) ||
         start_index >= end_index
     ) {
-      log_error("Invalid preview_window: start/end index out of range or invalid.")
+      log_error(
+        "Invalid preview_window: start/end index out of range or invalid."
+      )
     }
 
     sliced_pupil_data <- pupil_data[start_index:end_index, ]
 
     # time axis in ms for proper scaling
-    time_ms <- (sliced_pupil_data$time_scaled - min(sliced_pupil_data$time_scaled))
+    time_ms <- (sliced_pupil_data$time_scaled -
+      min(sliced_pupil_data$time_scaled))
 
     for (i in seq_along(pupil_steps)) {
       st <- pupil_data$time_orig[start_index]
@@ -501,7 +511,10 @@ plot.eyeris <- function(
 
   # add progressive summary plot at the end (if requested)
   if (add_progressive_summary) {
-    log_info("Creating progressive summary plot for block_{block}", verbose = verbose)
+    log_info(
+      "Creating progressive summary plot for block_{block}",
+      verbose = verbose
+    )
 
     tryCatch(
       {
@@ -518,7 +531,10 @@ plot.eyeris <- function(
           cex = 1.15
         )
 
-        log_success("Progressive summary plot created successfully!", verbose = verbose)
+        log_success(
+          "Progressive summary plot created successfully!",
+          verbose = verbose
+        )
       },
       error = function(e) {
         log_warn(
@@ -576,7 +592,10 @@ draw_random_epochs <- function(x, n, d, hz) {
     valid_epoch_found <- FALSE
 
     while (attempts < max_attempts && !valid_epoch_found) {
-      rand_start_secs <- sample(seq(min_time_secs, max_time_secs - d, by = step_size), 1)
+      rand_start_secs <- sample(
+        seq(min_time_secs, max_time_secs - d, by = step_size),
+        1
+      )
       rand_end_secs <- rand_start_secs + d
 
       epoch_data <- x |>
@@ -665,7 +684,11 @@ robust_plot <- function(y, x = NULL, ...) {
       # add vertical lines where there are NAs (using x values if available)
       na_idx <- which(is.na(y_orig))
       if (length(na_idx) > 0) {
-        abline(v = if (!is.null(x)) x_seq[na_idx] else na_idx, col = "black", lty = 2)
+        abline(
+          v = if (!is.null(x)) x_seq[na_idx] else na_idx,
+          col = "black",
+          lty = 2
+        )
       }
 
       # replace NA with -1 after drawing NA lines for continuity
@@ -792,7 +815,9 @@ plot_detrend_overlay <- function(
 
   # ensure prev col is a pupil col
   if (!grepl("^pupil_", prev_col)) {
-    log_warn("Previous column is not a pupil column. Cannot plot detrend overlay.")
+    log_warn(
+      "Previous column is not a pupil column. Cannot plot detrend overlay."
+    )
     # restore main plotting func layout
     par(mfrow = c(1, preview_n), oma = c(0, 0, 3, 0))
     return(FALSE)
@@ -810,7 +835,10 @@ plot_detrend_overlay <- function(
         type = "l",
         col = "black",
         lwd = 2,
-        main = paste0("detrend:\n", gsub("_", " > ", gsub("pupil_", "", detrend_step))),
+        main = paste0(
+          "detrend:\n",
+          gsub("_", " > ", gsub("pupil_", "", detrend_step))
+        ),
         xlab = "tracker time (s)",
         ylab = "pupil size (a.u.)"
       )
@@ -898,7 +926,9 @@ plot_gaze_heatmap <- function(
   } else {
     df <- eyeris
     if (is.null(screen_width) || is.null(screen_height)) {
-      log_error("Screen width and height must be provided with data frame inputs.")
+      log_error(
+        "Screen width and height must be provided with data frame inputs."
+      )
     }
   }
 
@@ -957,7 +987,13 @@ plot_gaze_heatmap <- function(
         zlim = c(0, 1)
       )
       rect(0, 0, screen_width, screen_height, border = "black", lwd = 2)
-      points(screen_width / 2, screen_height / 2, pch = 3, col = "red", cex = 1.5)
+      points(
+        screen_width / 2,
+        screen_height / 2,
+        pch = 3,
+        col = "red",
+        cex = 1.5
+      )
     },
     error = function(e) {
       plot(
@@ -973,7 +1009,13 @@ plot_gaze_heatmap <- function(
         ylim = c(screen_height, 0)
       )
       rect(0, 0, screen_width, screen_height, border = "black", lwd = 2)
-      points(screen_width / 2, screen_height / 2, pch = 3, col = "red", cex = 1.5)
+      points(
+        screen_width / 2,
+        screen_height / 2,
+        pch = 3,
+        col = "red",
+        cex = 1.5
+      )
     }
   )
 }
@@ -1184,5 +1226,8 @@ plot_binocular_correlation <- function(
   # reset plotting parameters
   par(mfrow = c(1, 1))
 
-  log_success("Created binocular correlation plots for block {block}", verbose = verbose)
+  log_success(
+    "Created binocular correlation plots for block {block}",
+    verbose = verbose
+  )
 }

--- a/R/utils-baseline.R
+++ b/R/utils-baseline.R
@@ -27,7 +27,14 @@ make_baseline_label <- function(baselined_data, epoch_id) {
 #' @return A list of baseline epoch data frames
 #'
 #' @keywords internal
-extract_baseline_epochs <- function(x, df, evs, time_range, matched_epochs, hz) {
+extract_baseline_epochs <- function(
+  x,
+  df,
+  evs,
+  time_range,
+  matched_epochs,
+  hz
+) {
   check_baseline_inputs(evs, time_range)
 
   time_col <- "time_orig"
@@ -41,7 +48,12 @@ extract_baseline_epochs <- function(x, df, evs, time_range, matched_epochs, hz) 
     n_samples <- duration / (1 / hz)
 
     for (i in seq_len(nrow(start))) {
-      current_epoch <- slice_epochs_with_limits(df, start$time[i], time_range, hz)
+      current_epoch <- slice_epochs_with_limits(
+        df,
+        start$time[i],
+        time_range,
+        hz
+      )
       baselines[[i]] <- current_epoch
     }
   } else {
@@ -56,7 +68,8 @@ extract_baseline_epochs <- function(x, df, evs, time_range, matched_epochs, hz) 
       duration <- (i_end - i_start) / hz
       n_samples <- duration * hz
 
-      baselines[[i]] <- df |> dplyr::filter(time_orig >= i_start & time_orig < i_end)
+      baselines[[i]] <- df |>
+        dplyr::filter(time_orig >= i_start & time_orig < i_end)
     }
   }
 

--- a/R/utils-checks.R
+++ b/R/utils-checks.R
@@ -24,7 +24,10 @@ check_and_create_dir <- function(basedir, dir = NULL, verbose = TRUE) {
 
     dir.create(dir, recursive = TRUE)
 
-    log_success("BIDS directory successfully created at: '{dir}'", verbose = verbose)
+    log_success(
+      "BIDS directory successfully created at: '{dir}'",
+      verbose = verbose
+    )
   }
 }
 
@@ -208,7 +211,10 @@ check_pupil_cols <- function(eyeris, fun) {
           block_num,
           fun
         )
-        stop(structure(list(message = err_m, call = match.call()), class = err_c))
+        stop(structure(
+          list(message = err_m, call = match.call()),
+          class = err_c
+        ))
       }
     }
   } else {
@@ -458,5 +464,7 @@ is_binocular_object <- function(x) {
 #'
 #' @keywords internal
 should_plot_binoc_cors <- function(x) {
-  is.list(x) && ("left" %in% names(x) && "right" %in% names(x)) || (isTRUE(x$binocular))
+  is.list(x) &&
+    ("left" %in% names(x) && "right" %in% names(x)) ||
+    (isTRUE(x$binocular))
 }

--- a/R/utils-database.R
+++ b/R/utils-database.R
@@ -10,11 +10,18 @@
 #' @return DBI database connection object
 #'
 #' @keywords internal
-connect_eyeris_database <- function(bids_dir, db_path = "my-project", verbose = FALSE) {
+connect_eyeris_database <- function(
+  bids_dir,
+  db_path = "my-project",
+  verbose = FALSE
+) {
   derivatives_dir <- file.path(bids_dir, "derivatives")
   if (!dir.exists(derivatives_dir)) {
     dir.create(derivatives_dir, recursive = TRUE)
-    log_info("Created derivatives directory: {derivatives_dir}", verbose = verbose)
+    log_info(
+      "Created derivatives directory: {derivatives_dir}",
+      verbose = verbose
+    )
   }
 
   # auto-append .eyerisdb extension if not present
@@ -38,7 +45,10 @@ connect_eyeris_database <- function(bids_dir, db_path = "my-project", verbose = 
           verbose = verbose
         )
       } else {
-        log_success("Created new eyeris database: {full_db_path}", verbose = verbose)
+        log_success(
+          "Created new eyeris database: {full_db_path}",
+          verbose = verbose
+        )
       }
 
       return(con)
@@ -72,7 +82,10 @@ disconnect_eyeris_database <- function(con, verbose = FALSE) {
       return(TRUE)
     },
     error = function(e) {
-      log_warn("Error disconnecting from database: {e$message}", verbose = verbose)
+      log_warn(
+        "Error disconnecting from database: {e$message}",
+        verbose = verbose
+      )
       return(FALSE)
     }
   )
@@ -185,7 +198,15 @@ write_eyeris_data_to_db <- function(
     return(FALSE)
   }
 
-  table_name <- create_table_name(data_type, sub, ses, task, run, eye_suffix, epoch_label)
+  table_name <- create_table_name(
+    data_type,
+    sub,
+    ses,
+    task,
+    run,
+    eye_suffix,
+    epoch_label
+  )
 
   tryCatch(
     {
@@ -371,7 +392,10 @@ eyeris_db_read <- function(
 
       union_queries <- c()
       for (table in valid_tables) {
-        union_queries <- c(union_queries, paste0("SELECT * FROM \"", table, "\""))
+        union_queries <- c(
+          union_queries,
+          paste0("SELECT * FROM \"", table, "\"")
+        )
       }
 
       query <- paste(union_queries, collapse = " UNION ALL ")
@@ -471,7 +495,10 @@ eyeris_db_connect <- function(bids_dir, db_path = "my-project") {
   tryCatch(
     {
       con <- DBI::dbConnect(duckdb::duckdb(), dbdir = full_db_path)
-      log_success("Connected to eyeris database: {full_db_path}", verbose = TRUE)
+      log_success(
+        "Connected to eyeris database: {full_db_path}",
+        verbose = TRUE
+      )
       return(con)
     },
     error = function(e) {
@@ -732,10 +759,15 @@ eyeris_db_collect <- function(
     tryCatch(
       {
         # handle epoch-specific data types
-        if (data_type %in% c("epochs", "confounds_events", "confounds_summary")) {
+        if (
+          data_type %in% c("epochs", "confounds_events", "confounds_summary")
+        ) {
           if (is.null(epoch_labels)) {
             # get all available epoch labels for this data type
-            type_tables <- all_tables[grepl(paste0("^", data_type, "_"), all_tables)]
+            type_tables <- all_tables[grepl(
+              paste0("^", data_type, "_"),
+              all_tables
+            )]
             if (length(type_tables) > 0) {
               # extract unique epoch labels from table names
               # handles both eye-L/eye-R and eyeL/eyeR formats
@@ -743,7 +775,11 @@ eyeris_db_collect <- function(
                 data_type,
                 "_[^_]+_[^_]+_[^_]+_[^_]+_(.+?)(?:_eye[LR]|_eye-[LR])?$"
               )
-              extracted_labels <- unique(gsub(epoch_pattern, "\\1", type_tables))
+              extracted_labels <- unique(gsub(
+                epoch_pattern,
+                "\\1",
+                type_tables
+              ))
               # remove failed matches (when pattern doesn't match, return original string)
               extracted_labels <- extracted_labels[
                 extracted_labels != type_tables &
@@ -787,9 +823,15 @@ eyeris_db_collect <- function(
             result_list[[data_type]] <- combined_data
           }
           # check if there are any tables for this data type at all
-          type_tables <- all_tables[grepl(paste0("^", data_type, "_"), all_tables)]
+          type_tables <- all_tables[grepl(
+            paste0("^", data_type, "_"),
+            all_tables
+          )]
           if (length(type_tables) == 0) {
-            log_warn("No tables found for data type: {data_type}", verbose = verbose)
+            log_warn(
+              "No tables found for data type: {data_type}",
+              verbose = verbose
+            )
           }
         } else {
           # handle non-epoch data types
@@ -806,14 +848,23 @@ eyeris_db_collect <- function(
             result_list[[data_type]] <- data
           }
           # check if there are any tables for this data type at all
-          type_tables <- all_tables[grepl(paste0("^", data_type, "_"), all_tables)]
+          type_tables <- all_tables[grepl(
+            paste0("^", data_type, "_"),
+            all_tables
+          )]
           if (length(type_tables) == 0) {
-            log_warn("No tables found for data type: {data_type}", verbose = verbose)
+            log_warn(
+              "No tables found for data type: {data_type}",
+              verbose = verbose
+            )
           }
         }
       },
       error = function(e) {
-        log_warn("Failed to extract {data_type}: {e$message}", verbose = verbose)
+        log_warn(
+          "Failed to extract {data_type}: {e$message}",
+          verbose = verbose
+        )
       }
     )
   }
@@ -828,7 +879,10 @@ eyeris_db_collect <- function(
   for (dtype in names(result_list)) {
     n_rows <- nrow(result_list[[dtype]])
     n_subjects <- length(unique(result_list[[dtype]]$subject_id))
-    log_info("  {dtype}: {n_rows} rows across {n_subjects} subjects", verbose = verbose)
+    log_info(
+      "  {dtype}: {n_rows} rows across {n_subjects} subjects",
+      verbose = verbose
+    )
   }
 
   return(result_list)
@@ -886,7 +940,11 @@ eyeris_db_collect <- function(
 #' }
 #'
 #' @export
-eyeris_db_summary <- function(bids_dir, db_path = "my-project", verbose = TRUE) {
+eyeris_db_summary <- function(
+  bids_dir,
+  db_path = "my-project",
+  verbose = TRUE
+) {
   # connect to database
   log_info("Connecting to eyeris database...", verbose = verbose)
 

--- a/R/utils-epoch.R
+++ b/R/utils-epoch.R
@@ -211,7 +211,11 @@ get_timestamps <- function(
 #' @return A data frame with matched events and extracted metadata
 #'
 #' @keywords internal
-merge_events_with_timeseries <- function(events, metadata_template, merge = TRUE) {
+merge_events_with_timeseries <- function(
+  events,
+  metadata_template,
+  merge = TRUE
+) {
   special_chars <- c(
     "\\",
     ".",
@@ -262,7 +266,11 @@ merge_events_with_timeseries <- function(events, metadata_template, merge = TRUE
     prefix <- substr(metadata_template, 1, nchar(metadata_template) - 1)
 
     for (char in special_chars) {
-      prefix <- stringr::str_replace_all(prefix, stringr::fixed(char), paste0("\\", char))
+      prefix <- stringr::str_replace_all(
+        prefix,
+        stringr::fixed(char),
+        paste0("\\", char)
+      )
     }
 
     regex_pattern <- paste0("^", prefix, ".*$")

--- a/R/utils-gallery.R
+++ b/R/utils-gallery.R
@@ -196,15 +196,15 @@ print_lightbox_img_html <- function(zip_path, image_filenames = NULL, verbose = 
     tryCatch(
       {
         file_size <- file.info(full_zip_path)$size
-        # only embed if file size is reasonable (< 10MB)
-        if (file_size < 10 * 1024 * 1024) {
+        # only embed if file size is reasonable (< 1GB)
+        if (file_size < 1024 * 1024 * 1024) {
           zip_bytes <- readBin(full_zip_path, "raw", file_size)
           zip_b64 <- base64enc::base64encode(zip_bytes)
           zip_data_url <- paste0("data:application/zip;base64,", zip_b64)
           log_success("Embedded zip file as data URL ({file_size} bytes)", verbose = TRUE)
         } else {
           log_warn(
-            "Zip file too large for data URL embedding ({file_size} bytes)",
+            "Zip file too large for data URL embedding ({file_size} bytes, limit: 1GB)",
             verbose = TRUE
           )
         }

--- a/R/utils-gallery.R
+++ b/R/utils-gallery.R
@@ -27,7 +27,11 @@ make_gallery <- function(eyeris, epochs, out, epoch_name, ...) {
   rmd_f <- file.path(out, report_filename)
 
   report_dir <- file.path(dirname(rmd_f), "source")
-  file.copy(system.file("www", package = "eyeris"), report_dir, recursive = TRUE)
+  file.copy(
+    system.file("www", package = "eyeris"),
+    report_dir,
+    recursive = TRUE
+  )
 
   report_date <- format(Sys.time(), "%B %d, %Y | %H:%M:%OS3")
   package_version <- as.character(utils::packageVersion("eyeris"))
@@ -50,7 +54,10 @@ make_gallery <- function(eyeris, epochs, out, epoch_name, ...) {
     "});</script>\n"
   )
 
-  css <- system.file(file.path("rmarkdown", "css", "report.css"), package = "eyeris")
+  css <- system.file(
+    file.path("rmarkdown", "css", "report.css"),
+    package = "eyeris"
+  )
 
   sticker_path <- system.file("figures", "sticker.png", package = "eyeris")
 
@@ -92,7 +99,11 @@ make_gallery <- function(eyeris, epochs, out, epoch_name, ...) {
     " - Run: ",
     params$run,
     "\n",
-    if (!is.null(params$eye_suffix)) paste0(" - Eye: ", params$eye_suffix, "\n") else "",
+    if (!is.null(params$eye_suffix)) {
+      paste0(" - Eye: ", params$eye_suffix, "\n")
+    } else {
+      ""
+    },
     " - BIDS Directory: ",
     out,
     "\n",
@@ -134,7 +145,11 @@ make_gallery <- function(eyeris, epochs, out, epoch_name, ...) {
 #' @return A character string containing HTML code for the lightbox gallery
 #'
 #' @keywords internal
-print_lightbox_img_html <- function(zip_path, image_filenames = NULL, verbose = TRUE) {
+print_lightbox_img_html <- function(
+  zip_path,
+  image_filenames = NULL,
+  verbose = TRUE
+) {
   # use legacy mode if zip_path is actually a vector of individual image paths
   if (length(zip_path) > 1 || !grepl("\\.zip$", zip_path)) {
     return(print_lightbox_img_html_legacy(zip_path))
@@ -201,7 +216,10 @@ print_lightbox_img_html <- function(zip_path, image_filenames = NULL, verbose = 
           zip_bytes <- readBin(full_zip_path, "raw", file_size)
           zip_b64 <- base64enc::base64encode(zip_bytes)
           zip_data_url <- paste0("data:application/zip;base64,", zip_b64)
-          log_success("Embedded zip file as data URL ({file_size} bytes)", verbose = TRUE)
+          log_success(
+            "Embedded zip file as data URL ({file_size} bytes)",
+            verbose = TRUE
+          )
         } else {
           log_warn(
             "Zip file too large for data URL embedding ({file_size} bytes, limit: 1GB)",
@@ -210,7 +228,10 @@ print_lightbox_img_html <- function(zip_path, image_filenames = NULL, verbose = 
         }
       },
       error = function(e) {
-        log_warn("Could not embed zip file as data URL: {e$message}", verbose = TRUE)
+        log_warn(
+          "Could not embed zip file as data URL: {e$message}",
+          verbose = TRUE
+        )
       }
     )
   }

--- a/R/utils-render_report.R
+++ b/R/utils-render_report.R
@@ -41,7 +41,10 @@ make_report <- function(eyeris, out, plots, eye_suffix = NULL, ...) {
 
   report_date <- format(Sys.time(), "%B %d, %Y | %H:%M:%OS3")
   package_version <- as.character(utils::packageVersion("eyeris"))
-  css <- system.file(file.path("rmarkdown", "css", "report.css"), package = "eyeris")
+  css <- system.file(
+    file.path("rmarkdown", "css", "report.css"),
+    package = "eyeris"
+  )
 
   sticker_path <- system.file("figures", "sticker.png", package = "eyeris")
 
@@ -50,7 +53,11 @@ make_report <- function(eyeris, out, plots, eye_suffix = NULL, ...) {
     recursive = FALSE,
     full.names = FALSE
   )
-  run_ids <- sort(as.integer(gsub("run-", "", grep("^run-\\d+$", run_ids, value = TRUE))))
+  run_ids <- sort(as.integer(gsub(
+    "run-",
+    "",
+    grep("^run-\\d+$", run_ids, value = TRUE)
+  )))
 
   run_info <- paste(
     " - Runs: ",
@@ -134,10 +141,18 @@ make_report <- function(eyeris, out, plots, eye_suffix = NULL, ...) {
       call_stack = sanitize_call_stack(eyeris$params)
     )
 
-    meta_path <- file.path(metadata_dir, sprintf("run-%02d_metadata.json", run_id))
+    meta_path <- file.path(
+      metadata_dir,
+      sprintf("run-%02d_metadata.json", run_id)
+    )
 
     if (!file.exists(meta_path)) {
-      jsonlite::write_json(run_metadata, meta_path, pretty = TRUE, auto_unbox = TRUE)
+      jsonlite::write_json(
+        run_metadata,
+        meta_path,
+        pretty = TRUE,
+        auto_unbox = TRUE
+      )
     } else {
       log_warn("Metadata file already exists for {run_id}: {meta_path}")
     }
@@ -290,10 +305,20 @@ make_md_table <- function(df) {
 #' @keywords internal
 make_md_table_multiline <- function(df) {
   md_table <- paste0("| ", paste(colnames(df), collapse = " | "), " |\n")
-  md_table <- paste0(md_table, "|", paste(rep("---", ncol(df)), collapse = "|"), "|\n")
+  md_table <- paste0(
+    md_table,
+    "|",
+    paste(rep("---", ncol(df)), collapse = "|"),
+    "|\n"
+  )
   for (i in seq_len(nrow(df))) {
     row <- df[i, ]
-    md_table <- paste0(md_table, "| ", paste(as.character(row), collapse = " | "), " |\n")
+    md_table <- paste0(
+      md_table,
+      "| ",
+      paste(as.character(row), collapse = " | "),
+      " |\n"
+    )
   }
   md_table
 }
@@ -360,7 +385,13 @@ print_plots <- function(plots, eye_suffix = NULL) {
         }
 
         placeholder_detected <- FALSE
-        placeholder_patterns <- c("no_data", "placeholder", "error", "No_data", "NoData")
+        placeholder_patterns <- c(
+          "no_data",
+          "placeholder",
+          "error",
+          "No_data",
+          "NoData"
+        )
         if (
           length(sorted_plot_paths) == 1 ||
             all(sapply(sorted_plot_paths, function(x) {
@@ -375,7 +406,10 @@ print_plots <- function(plots, eye_suffix = NULL) {
         }
 
         if (placeholder_detected) {
-          md_plots <- paste0(md_plots, "> **No data available for this run.**\n\n")
+          md_plots <- paste0(
+            md_plots,
+            "> **No data available for this run.**\n\n"
+          )
         }
 
         for (fig_path in sorted_plot_paths) {
@@ -384,7 +418,10 @@ print_plots <- function(plots, eye_suffix = NULL) {
         }
 
         # detrend diagnostics - check for eye_suffix version first
-        detrend_plot_path <- file.path(run_dir, paste0("run-", run_num, "_detrend.png"))
+        detrend_plot_path <- file.path(
+          run_dir,
+          paste0("run-", run_num, "_detrend.png")
+        )
 
         # if eye_suffix is provided, look for the suffixed version
         if (!is.null(eye_suffix)) {
@@ -459,7 +496,12 @@ save_detrend_plots <- function(
     ) {
       pupil_steps <- grep("^pupil_", names(pupil_data), value = TRUE)
 
-      grDevices::jpeg(filename = detrend_path, width = 1850, height = 1500, res = 300)
+      grDevices::jpeg(
+        filename = detrend_path,
+        width = 1850,
+        height = 1500,
+        res = 300
+      )
 
       plot_detrend_overlay(
         pupil_data = pupil_data,
@@ -688,7 +730,12 @@ save_progressive_summary_plots <- function(
 
     # if the progressive plot already exists, just include it
     if (file.exists(progressive_path)) {
-      relative_path <- gsub("^.*?(?=source/)", "", progressive_path, perl = TRUE)
+      relative_path <- gsub(
+        "^.*?(?=source/)",
+        "",
+        progressive_path,
+        perl = TRUE
+      )
       md_content <- paste0(
         md_content,
         "### ",
@@ -720,7 +767,12 @@ save_progressive_summary_plots <- function(
       next
     }
 
-    grDevices::png(filename = progressive_path, width = 7000, height = 6000, res = 300)
+    grDevices::png(
+      filename = progressive_path,
+      width = 7000,
+      height = 6000,
+      res = 300
+    )
 
     make_prog_summary_plot(
       pupil_data = pupil_data,

--- a/R/utils-render_report.R
+++ b/R/utils-render_report.R
@@ -179,7 +179,7 @@ make_report <- function(eyeris, out, plots, eye_suffix = NULL, ...) {
     }
   }
 
-  title <- "`eyeris` preprocessing summary report"
+  title <- "`eyeris` preprocessing report"
 
   content <- paste0(
     "---\n",

--- a/R/utils-zip-cleanup.R
+++ b/R/utils-zip-cleanup.R
@@ -44,7 +44,6 @@ zip_and_cleanup_source_figures <- function(
     }
     zip_filename <- paste0(zip_filename, ".zip")
     existing_zip_path <- file.path(figures_dir, zip_filename)
-    
     if (file.exists(existing_zip_path)) {
       unlink(existing_zip_path)
       log_info("Removed existing zip file: {zip_filename}", verbose = verbose)
@@ -96,7 +95,6 @@ zip_and_cleanup_source_figures <- function(
             # move zip file to parent figures directory
             final_zip_path <- file.path(figures_dir, zip_filename)
             file.rename(zip_filename, final_zip_path)
-            
             created_zips <- c(created_zips, final_zip_path)
 
             log_success(
@@ -107,14 +105,10 @@ zip_and_cleanup_source_figures <- function(
         }
 
         setwd(current_dir)
-        
         # remove the entire run directory after successful zip creation
         if (file.exists(final_zip_path)) {
           unlink(run_dir, recursive = TRUE)
-          log_success(
-            "Removed run directory: {run_name}",
-            verbose = verbose
-          )
+          log_success("Removed run directory: {run_name}", verbose = verbose)
         }
       },
       error = function(e) {

--- a/R/utils-zip-cleanup.R
+++ b/R/utils-zip-cleanup.R
@@ -19,7 +19,10 @@ zip_and_cleanup_source_figures <- function(
   figures_dir <- file.path(report_path, "source", "figures")
 
   if (!dir.exists(figures_dir)) {
-    log_warn("Source figures directory not found: {figures_dir}", verbose = verbose)
+    log_warn(
+      "Source figures directory not found: {figures_dir}",
+      verbose = verbose
+    )
     return(NULL)
   }
 
@@ -121,7 +124,10 @@ zip_and_cleanup_source_figures <- function(
             )
           }
         )
-        log_warn("Failed to create zip for {run_name}: {e$message}", verbose = verbose)
+        log_warn(
+          "Failed to create zip for {run_name}: {e$message}",
+          verbose = verbose
+        )
       }
     )
   }
@@ -146,23 +152,35 @@ cleanup_source_figures_post_render <- function(
   eye_suffix = NULL,
   verbose = FALSE
 ) {
-  log_info("Starting post-render cleanup of source figure files...", verbose = verbose)
+  log_info(
+    "Starting post-render cleanup of source figure files...",
+    verbose = verbose
+  )
 
   figures_dir <- file.path(report_path, "source", "figures")
 
   if (!dir.exists(figures_dir)) {
-    log_info("Source figures directory not found: {figures_dir}", verbose = verbose)
+    log_info(
+      "Source figures directory not found: {figures_dir}",
+      verbose = verbose
+    )
     return(invisible(FALSE))
   }
 
   tryCatch(
     {
       unlink(figures_dir, recursive = TRUE)
-      log_success("Removed entire source/figures directory (images embedded in HTML)", verbose = verbose)
+      log_success(
+        "Removed entire source/figures directory (images embedded in HTML)",
+        verbose = verbose
+      )
       return(invisible(TRUE))
     },
     error = function(e) {
-      log_warn("Failed to remove source/figures directory: {e$message}", verbose = verbose)
+      log_warn(
+        "Failed to remove source/figures directory: {e$message}",
+        verbose = verbose
+      )
       return(invisible(FALSE))
     }
   )

--- a/R/utils-zip-cleanup.R
+++ b/R/utils-zip-cleanup.R
@@ -106,7 +106,7 @@ zip_and_cleanup_source_figures <- function(
 
         setwd(current_dir)
         # remove the entire run directory after successful zip creation
-        if (file.exists(final_zip_path)) {
+        if (!is.null(final_zip_path) && file.exists(final_zip_path)) {
           unlink(run_dir, recursive = TRUE)
           log_success("Removed run directory: {run_name}", verbose = verbose)
         }

--- a/R/utils-zip-cleanup.R
+++ b/R/utils-zip-cleanup.R
@@ -131,14 +131,14 @@ zip_and_cleanup_source_figures <- function(
 
 #' Clean up source figures after report generation
 #'
-#' Wrapper function to zip and cleanup source figure files after the main
-#' HTML report has been generated and the R Markdown source has been cleaned up.
+#' Removes the entire source/figures directory after the main HTML report has
+#' been generated since all images are now embedded in the HTML as data URLs.
 #'
 #' @param report_path Path to the report directory
-#' @param eye_suffix Optional eye suffix for binocular data
+#' @param eye_suffix Optional eye suffix for binocular data (unused but kept for compatibility)
 #' @param verbose Whether to print verbose output
 #'
-#' @return Invisibly returns list of created zip files
+#' @return Invisibly returns TRUE if cleanup was successful, FALSE otherwise
 #'
 #' @keywords internal
 cleanup_source_figures_post_render <- function(
@@ -148,20 +148,22 @@ cleanup_source_figures_post_render <- function(
 ) {
   log_info("Starting post-render cleanup of source figure files...", verbose = verbose)
 
-  zip_files <- zip_and_cleanup_source_figures(
-    report_path = report_path,
-    eye_suffix = eye_suffix,
-    verbose = verbose
-  )
+  figures_dir <- file.path(report_path, "source", "figures")
 
-  if (!is.null(zip_files) && length(zip_files) > 0) {
-    log_success(
-      "Post-render cleanup complete. Created {length(zip_files)} zip files.",
-      verbose = verbose
-    )
-  } else {
-    log_info("No figure files found to cleanup.", verbose = verbose)
+  if (!dir.exists(figures_dir)) {
+    log_info("Source figures directory not found: {figures_dir}", verbose = verbose)
+    return(invisible(FALSE))
   }
 
-  invisible(zip_files)
+  tryCatch(
+    {
+      unlink(figures_dir, recursive = TRUE)
+      log_success("Removed entire source/figures directory (images embedded in HTML)", verbose = verbose)
+      return(invisible(TRUE))
+    },
+    error = function(e) {
+      log_warn("Failed to remove source/figures directory: {e$message}", verbose = verbose)
+      return(invisible(FALSE))
+    }
+  )
 }

--- a/R/utils-zip-cleanup.R
+++ b/R/utils-zip-cleanup.R
@@ -37,6 +37,19 @@ zip_and_cleanup_source_figures <- function(
   for (run_dir in run_dirs) {
     run_name <- basename(run_dir)
 
+    # remove existing zip files if they exist (for reprocessing)
+    zip_filename <- run_name
+    if (!is.null(eye_suffix)) {
+      zip_filename <- paste0(zip_filename, "_", eye_suffix)
+    }
+    zip_filename <- paste0(zip_filename, ".zip")
+    existing_zip_path <- file.path(figures_dir, zip_filename)
+    
+    if (file.exists(existing_zip_path)) {
+      unlink(existing_zip_path)
+      log_info("Removed existing zip file: {zip_filename}", verbose = verbose)
+    }
+
     image_files <- list.files(
       run_dir,
       pattern = "\\.(png|jpg|jpeg)$",
@@ -55,12 +68,12 @@ zip_and_cleanup_source_figures <- function(
       next
     }
 
-    zip_filename <- paste0(run_name, "_figures")
+    zip_filename <- run_name
     if (!is.null(eye_suffix)) {
       zip_filename <- paste0(zip_filename, "_", eye_suffix)
     }
     zip_filename <- paste0(zip_filename, ".zip")
-    zip_path <- file.path(run_dir, zip_filename)
+    zip_path <- file.path(figures_dir, zip_filename)
 
     tryCatch(
       {
@@ -80,33 +93,29 @@ zip_and_cleanup_source_figures <- function(
           utils::zip(zip_filename, files = relative_files, flags = "-r9X")
 
           if (file.exists(zip_filename)) {
-            # delete individual image files after successful zip creation
-            for (file in image_files) {
-              if (file.exists(file)) {
-                unlink(file)
-              }
-            }
-
-            empty_dirs <- list.dirs(run_dir, full.names = TRUE, recursive = TRUE)
-            empty_dirs <- empty_dirs[empty_dirs != run_dir] # don't remove the run dir itself
-
-            for (dir in rev(empty_dirs)) {
-              # remove in reverse order (deepest first)
-              if (length(list.files(dir, all.files = TRUE, no.. = TRUE)) == 0) {
-                unlink(dir, recursive = TRUE)
-              }
-            }
-
-            created_zips <- c(created_zips, file.path(run_dir, zip_filename))
+            # move zip file to parent figures directory
+            final_zip_path <- file.path(figures_dir, zip_filename)
+            file.rename(zip_filename, final_zip_path)
+            
+            created_zips <- c(created_zips, final_zip_path)
 
             log_success(
-              "Created {zip_filename} with {length(relative_files)} images, removed individual files",
+              "Created {zip_filename} with {length(relative_files)} images",
               verbose = verbose
             )
           }
         }
 
         setwd(current_dir)
+        
+        # remove the entire run directory after successful zip creation
+        if (file.exists(final_zip_path)) {
+          unlink(run_dir, recursive = TRUE)
+          log_success(
+            "Removed run directory: {run_name}",
+            verbose = verbose
+          )
+        }
       },
       error = function(e) {
         tryCatch(

--- a/R/utils-zip-gallery.R
+++ b/R/utils-zip-gallery.R
@@ -50,7 +50,9 @@ create_epoch_images_zip <- function(
     {
       for (group in epoch_groups) {
         group_df <- epochs_to_save[[epoch_index]][[block_name]]
-        group_df <- group_df[group_df[[report_epoch_grouping_var_col]] == group, ]
+        group_df <- group_df[
+          group_df[[report_epoch_grouping_var_col]] == group,
+        ]
 
         for (pstep in seq_along(pupil_steps)) {
           if (grepl("z", pupil_steps[pstep])) {
@@ -123,7 +125,9 @@ create_epoch_images_zip <- function(
 
       for (group in epoch_groups) {
         group_df <- epochs_to_save[[epoch_index]][[block_name]]
-        group_df <- group_df[group_df[[report_epoch_grouping_var_col]] == group, ]
+        group_df <- group_df[
+          group_df[[report_epoch_grouping_var_col]] == group,
+        ]
 
         if (all(c("eye_x", "eye_y") %in% colnames(group_df))) {
           heatmap_filename <- file.path(
@@ -153,7 +157,11 @@ create_epoch_images_zip <- function(
                 screen_height = eyeris_object$info$screen.y,
                 n_bins = 30,
                 col_palette = "viridis",
-                main = sprintf("%s\nGaze Heatmap (run-%02d)", group, run_dir_num),
+                main = sprintf(
+                  "%s\nGaze Heatmap (run-%02d)",
+                  group,
+                  run_dir_num
+                ),
                 eye_suffix = eye_suffix
               )
             },

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
+# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
 
 <!-- badges: start -->
 [![dev branch status](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/badges/dev-branch-version.svg)](https://github.com/shawntz/eyeris/tree/dev)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ set.seed(32)
 
 library(eyeris)
 #> 
-#> eyeris v2.1.1.9002 - Lumpy Space Princess ꒰•ᴗ•｡꒱۶
+#> eyeris v2.1.1.9003 - Lumpy Space Princess ꒰•ᴗ•｡꒱۶
 #> Welcome! Type ?`eyeris` to get started.
 
 demo_data <- eyelink_asc_demo_dataset()
@@ -201,20 +201,20 @@ eyeris_preproc <- glassbox(
   demo_data,
   lpfilt = list(plot_freqz = FALSE)
 )
-#> ✔ [2025-08-03 13:56:10] [OKAY] Running eyeris::load_asc()
-#> ℹ [2025-08-03 13:56:10] [INFO] Processing block: block_1
-#> ✔ [2025-08-03 13:56:10] [OKAY] Running eyeris::deblink() for block_1
-#> ✔ [2025-08-03 13:56:11] [OKAY] Running eyeris::detransient() for block_1
-#> ✔ [2025-08-03 13:56:11] [OKAY] Running eyeris::interpolate() for block_1
-#> ✔ [2025-08-03 13:56:11] [OKAY] Running eyeris::lpfilt() for block_1
-#> ! [2025-08-03 13:56:11] [WARN] Skipping eyeris::downsample() for block_1
-#> ! [2025-08-03 13:56:11] [WARN] Skipping eyeris::bin() for block_1
-#> ! [2025-08-03 13:56:11] [WARN] Skipping eyeris::detrend() for block_1
-#> ✔ [2025-08-03 13:56:11] [OKAY] Running eyeris::zscore() for block_1
-#> ℹ [2025-08-03 13:56:11] [INFO] Block processing summary:
-#> ℹ [2025-08-03 13:56:11] [INFO] block_1: OK (steps: 6, latest:
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::load_asc()
+#> ℹ [2025-08-03 22:42:07] [INFO] Processing block: block_1
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::deblink() for block_1
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::detransient() for block_1
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::interpolate() for block_1
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::lpfilt() for block_1
+#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::downsample() for block_1
+#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::bin() for block_1
+#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::detrend() for block_1
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::zscore() for block_1
+#> ℹ [2025-08-03 22:42:07] [INFO] Block processing summary:
+#> ℹ [2025-08-03 22:42:07] [INFO] block_1: OK (steps: 6, latest:
 #> pupil_raw_deblink_detransient_interpolate_lpfilt_z)
-#> ✔ [2025-08-03 13:56:11] [OKAY] Running eyeris::summarize_confounds()
+#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::summarize_confounds()
 ```
 
 ### Step-wise correction of pupillary signal
@@ -240,17 +240,17 @@ plot(eyeris_preproc,
   preview_window = c(start_time, end_time),
   add_progressive_summary = TRUE
 )
-#> ℹ [2025-08-03 13:56:11] [INFO] Plotting block 1 with sampling rate 1000 Hz from
+#> ℹ [2025-08-03 22:42:07] [INFO] Plotting block 1 with sampling rate 1000 Hz from
 #> possible blocks: 1
 ```
 
 <img src="man/figures/README-timeseries-plot-1.png" width="100%" /><img src="man/figures/README-timeseries-plot-2.png" width="100%" /><img src="man/figures/README-timeseries-plot-3.png" width="100%" /><img src="man/figures/README-timeseries-plot-4.png" width="100%" /><img src="man/figures/README-timeseries-plot-5.png" width="100%" /><img src="man/figures/README-timeseries-plot-6.png" width="100%" />
 
-    #> ℹ [2025-08-03 13:56:11] [INFO] Creating progressive summary plot for block_1
+    #> ℹ [2025-08-03 22:42:08] [INFO] Creating progressive summary plot for block_1
 
 <img src="man/figures/README-timeseries-plot-7.png" width="100%" />
 
-    #> ✔ [2025-08-03 13:56:12] [OKAY] Progressive summary plot created successfully!
+    #> ✔ [2025-08-03 22:42:08] [OKAY] Progressive summary plot created successfully!
 
     plot_gaze_heatmap(
       eyeris = eyeris_preproc,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd-->
 
-# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
+# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
 
 <!-- badges: start -->
 
@@ -201,20 +201,20 @@ eyeris_preproc <- glassbox(
   demo_data,
   lpfilt = list(plot_freqz = FALSE)
 )
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::load_asc()
-#> ℹ [2025-08-03 22:42:07] [INFO] Processing block: block_1
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::deblink() for block_1
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::detransient() for block_1
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::interpolate() for block_1
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::lpfilt() for block_1
-#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::downsample() for block_1
-#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::bin() for block_1
-#> ! [2025-08-03 22:42:07] [WARN] Skipping eyeris::detrend() for block_1
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::zscore() for block_1
-#> ℹ [2025-08-03 22:42:07] [INFO] Block processing summary:
-#> ℹ [2025-08-03 22:42:07] [INFO] block_1: OK (steps: 6, latest:
+#> ✔ [2025-08-03 22:52:59] [OKAY] Running eyeris::load_asc()
+#> ℹ [2025-08-03 22:53:00] [INFO] Processing block: block_1
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::deblink() for block_1
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::detransient() for block_1
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::interpolate() for block_1
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::lpfilt() for block_1
+#> ! [2025-08-03 22:53:00] [WARN] Skipping eyeris::downsample() for block_1
+#> ! [2025-08-03 22:53:00] [WARN] Skipping eyeris::bin() for block_1
+#> ! [2025-08-03 22:53:00] [WARN] Skipping eyeris::detrend() for block_1
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::zscore() for block_1
+#> ℹ [2025-08-03 22:53:00] [INFO] Block processing summary:
+#> ℹ [2025-08-03 22:53:00] [INFO] block_1: OK (steps: 6, latest:
 #> pupil_raw_deblink_detransient_interpolate_lpfilt_z)
-#> ✔ [2025-08-03 22:42:07] [OKAY] Running eyeris::summarize_confounds()
+#> ✔ [2025-08-03 22:53:00] [OKAY] Running eyeris::summarize_confounds()
 ```
 
 ### Step-wise correction of pupillary signal
@@ -240,17 +240,17 @@ plot(eyeris_preproc,
   preview_window = c(start_time, end_time),
   add_progressive_summary = TRUE
 )
-#> ℹ [2025-08-03 22:42:07] [INFO] Plotting block 1 with sampling rate 1000 Hz from
+#> ℹ [2025-08-03 22:53:00] [INFO] Plotting block 1 with sampling rate 1000 Hz from
 #> possible blocks: 1
 ```
 
 <img src="man/figures/README-timeseries-plot-1.png" width="100%" /><img src="man/figures/README-timeseries-plot-2.png" width="100%" /><img src="man/figures/README-timeseries-plot-3.png" width="100%" /><img src="man/figures/README-timeseries-plot-4.png" width="100%" /><img src="man/figures/README-timeseries-plot-5.png" width="100%" /><img src="man/figures/README-timeseries-plot-6.png" width="100%" />
 
-    #> ℹ [2025-08-03 22:42:08] [INFO] Creating progressive summary plot for block_1
+    #> ℹ [2025-08-03 22:53:00] [INFO] Creating progressive summary plot for block_1
 
 <img src="man/figures/README-timeseries-plot-7.png" width="100%" />
 
-    #> ✔ [2025-08-03 22:42:08] [OKAY] Progressive summary plot created successfully!
+    #> ✔ [2025-08-03 22:53:01] [OKAY] Progressive summary plot created successfully!
 
     plot_gaze_heatmap(
       eyeris = eyeris_preproc,

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,8 @@ news:
     cran_dates: true
     releases:
     - text: "LATEST DEV RELEASES"
+    - text: "v2.1.1.9003 (devel)"
+      href: news/index.html#eyeris-2119003-lumpy-space-princess-lumpy-space-princess
     - text: "v2.1.1.9002 (devel)"
       href: news/index.html#eyeris-2119002-lumpy-space-princess-lumpy-space-princess
     - text: "v2.1.1.9001 (devel)"

--- a/man/cleanup_source_figures_post_render.Rd
+++ b/man/cleanup_source_figures_post_render.Rd
@@ -13,15 +13,15 @@ cleanup_source_figures_post_render(
 \arguments{
 \item{report_path}{Path to the report directory}
 
-\item{eye_suffix}{Optional eye suffix for binocular data}
+\item{eye_suffix}{Optional eye suffix for binocular data (unused but kept for compatibility)}
 
 \item{verbose}{Whether to print verbose output}
 }
 \value{
-Invisibly returns list of created zip files
+Invisibly returns TRUE if cleanup was successful, FALSE otherwise
 }
 \description{
-Wrapper function to zip and cleanup source figure files after the main
-HTML report has been generated and the R Markdown source has been cleaned up.
+Removes the entire source/figures directory after the main HTML report has
+been generated since all images are now embedded in the HTML as data URLs.
 }
 \keyword{internal}

--- a/tests/testthat/test-bin.R
+++ b/tests/testthat/test-bin.R
@@ -8,7 +8,11 @@ test_that("bin() works as expected", {
 
   # test bin() --------------------------------------------------------------
   bins_per_second <- 10
-  binned <- eyeris::bin(data, bins_per_second = bins_per_second, method = "mean")
+  binned <- eyeris::bin(
+    data,
+    bins_per_second = bins_per_second,
+    method = "mean"
+  )
   expect_equal(binned$decimated.sample.rate, bins_per_second)
   expect_lt(nrow(binned$timeseries$block_1), nrow(data$timeseries$block_1))
   expect_true(!any(is.na(binned$timeseries$block_1$pupil_raw_interpolate_bin)))

--- a/tests/testthat/test-binocular.R
+++ b/tests/testthat/test-binocular.R
@@ -44,5 +44,8 @@ test_that("is_binocular_object correctly identifies binocular and non-binocular 
     regular_result,
     info = "Regular object should not be identified as binocular"
   )
-  expect_true(binocular_result, info = "Binocular object should be correctly identified")
+  expect_true(
+    binocular_result,
+    info = "Binocular object should be correctly identified"
+  )
 })

--- a/tests/testthat/test-database.R
+++ b/tests/testthat/test-database.R
@@ -134,7 +134,11 @@ test_that("database integration works correctly", {
 
   # test 4: csv and database helper function
   test_that("write_csv_and_db helper function works", {
-    con <- connect_eyeris_database(temp_bids_dir, "helper-test", verbose = FALSE)
+    con <- connect_eyeris_database(
+      temp_bids_dir,
+      "helper-test",
+      verbose = FALSE
+    )
 
     test_data <- data.frame(
       value = c(100, 200, 300),
@@ -218,7 +222,11 @@ test_that("database integration works correctly", {
     disconnect_eyeris_database(con1, verbose = FALSE)
 
     # test custom name (extension should be auto-added)
-    con2 <- connect_eyeris_database(temp_bids_dir, "custom-study", verbose = FALSE)
+    con2 <- connect_eyeris_database(
+      temp_bids_dir,
+      "custom-study",
+      verbose = FALSE
+    )
     expect_s4_class(con2, "duckdb_connection")
     expect_true(file.exists(file.path(
       temp_bids_dir,
@@ -310,7 +318,9 @@ test_that("database integration works correctly", {
 
     # check table was created with epoch label
     tables <- DBI::dbListTables(con)
-    expect_true("epoch_timeseries_005_01_epochtest_run01_prepostprobe" %in% tables)
+    expect_true(
+      "epoch_timeseries_005_01_epochtest_run01_prepostprobe" %in% tables
+    )
 
     # verify data contains epoch label metadata
     table_data <- DBI::dbReadTable(

--- a/tests/testthat/test-downsample.R
+++ b/tests/testthat/test-downsample.R
@@ -8,7 +8,11 @@ test_that("downsample() works as expected", {
 
   # test downsample() -------------------------------------------------------
   target_fs <- 500
-  downsampled <- eyeris::downsample(data, target_fs = target_fs, plot_freqz = FALSE)
+  downsampled <- eyeris::downsample(
+    data,
+    target_fs = target_fs,
+    plot_freqz = FALSE
+  )
   expect_equal(downsampled$decimated.sample.rate, target_fs)
   expect_lt(nrow(downsampled$timeseries$block_1), nrow(data$timeseries$block_1))
   expect_true(

--- a/tests/testthat/test-load_asc.R
+++ b/tests/testthat/test-load_asc.R
@@ -2,7 +2,14 @@ test_that("load_asc function returns list with expected objects", {
   eye_file <- system.file("extdata", "memory.asc", package = "eyeris")
   result <- eyeris::load_asc(eye_file)
 
-  expected_objects <- c("file", "timeseries", "events", "blinks", "info", "latest")
+  expected_objects <- c(
+    "file",
+    "timeseries",
+    "events",
+    "blinks",
+    "info",
+    "latest"
+  )
   actual_objects <- names(result)
 
   expect_true(


### PR DESCRIPTION
## Changelog entry

- **ENH**: Added post-render cleanup of figures directories in `pipeline-bidsify.R`. Enhanced `zip_and_cleanup_source_figures` to remove existing zip files before reprocessing, move new zip files to the parent figures directory, and delete run directories after successful zipping. This streamlines figures management and prevents leftover files from previous runs, by @shawntz in #261.

### Problem Addressed

Further cleans up number of derived files in `eyeris` BIDS directories (which is especially useful for cloud compute deployments).

The new behavior will be:
 
1. Create zip files in the `figures/` directory (i.e., one level up from the run directories)
2. Remove existing zip files when reprocessing
3. Remove the entire `run-XX/` directories after successful zip creation

As such, the final file structure will be:

```bash
  sub-01/
  └── ses-enc/
      ├── sub-01.html
      └── source/
          ├── figures/
          │   ├── run-01.zip  # now contains all images from run-01/
          │   ├── run-02.zip  # now contains all images from run-02/
          │   └── run-03.zip  # now contains all images from run-03/
          └── logs/
              ├── run-01_metadata.json
              ├── run-02_metadata.json
              └── run-03_metadata.json
```

## 🔧 Minor improvements and fixes

- **RF - post-render cleanup to remove figures directory**: The `cleanup_source_figures_post_render()` function now removes the entire `source/figures` directory after report generation, as images are embedded in the `HTML`. Documentation and comments updated to reflect this change, and unused parameters are noted for compatibility, by @shawntz in #261.

- **RF - increase zip file embed size limit to 1GB**: Raised the maximum allowed zip file size for data `URL` embedding from `10MB` to `1GB` in `print_lightbox_img_html()`. Updated warning message to reflect the new limit, by @shawntz in #261.

- **RF - update report title in `make_report` function**: Changed the report title from 'preprocessing summary report' to 'preprocessing report' for consistency and clarity, by @shawntz in #261.

- **CHORE - update logo image URL**: Changed the `logo` image source in `README` files to use a `GitHub raw URL` for better compatibility, by @shawntz in #261.

## Breaking changes checklist

- [x] This PR includes breaking changes
- [x] Version number has been bumped appropriately
- [x] Migration guide added to NEWS.md
