### PR TITLE
FF: Handle non-finite values in plotting xlim ranges

### DIFF
--- a/R/plot.eyeris.R
+++ b/R/plot.eyeris.R
@@ -674,12 +674,14 @@ robust_plot <- function(y, x = NULL, ...) {
       }
 
       # init placeholder line
-      plot(
-        x_seq,
-        ifelse(is.na(y_orig), NA, y_orig),
-        xlim = range(x_seq, na.rm = TRUE),
-        ...
-      )
+      # handle case where x_seq has no finite values
+      x_range <- range(x_seq, na.rm = TRUE, finite = TRUE)
+      if (any(!is.finite(x_range))) {
+        # fallback to default range if no finite values
+        x_range <- c(0, length(x_seq))
+      }
+
+      plot(x_seq, ifelse(is.na(y_orig), NA, y_orig), xlim = x_range, ...)
 
       # add vertical lines where there are NAs (using x values if available)
       na_idx <- which(is.na(y_orig))

--- a/R/utils-zip-gallery.R
+++ b/R/utils-zip-gallery.R
@@ -100,9 +100,20 @@ create_epoch_images_zip <- function(
               )
             )
           } else {
+            # handle case where timebin has no finite values
+            timebin_range <- range(
+              group_df$timebin,
+              na.rm = TRUE,
+              finite = TRUE
+            )
+            if (any(!is.finite(timebin_range))) {
+              # fallback to default range if no finite values
+              timebin_range <- c(0, 1)
+            }
+
             plot(
               NA,
-              xlim = range(group_df$timebin, na.rm = TRUE),
+              xlim = timebin_range,
               ylim = c(0, 1),
               type = "n",
               xlab = "time (s)",


### PR DESCRIPTION
## Summary

Fixes plotting errors that occur when timebin or x_seq data contains only NA values or no finite values, causing `range()` to return `Inf/-Inf` and `plot.window()` to fail.

### Problem Solved
Users encountered this error during epoch visualization:
```
Error in plot.window(...) : need finite 'xlim' values
```

This occurred when epoch data had insufficient finite timebin values, causing `range(group_df$timebin, na.rm = TRUE)` to return non-finite values.

### Solution
- **Add `finite=TRUE` parameter** to `range()` calls to exclude infinite values
- **Add fallback logic** when no finite values exist:
  - `utils-zip-gallery.R`: defaults to `c(0, 1)` for timebin range
  - `plot.eyeris.R`: defaults to `c(0, length(x_seq))` for x_range
- **Defensive programming** prevents plotting crashes in edge cases

### Files Changed
- `R/utils-zip-gallery.R`: Fixed epoch image generation plotting
- `R/plot.eyeris.R`: Fixed general eyeris plotting function

### Technical Details
The issue occurred in these specific scenarios:
1. **Empty epoch data**: When `group_df$timebin` contains only `NA` values
2. **Invalid time sequences**: When time data is corrupted or missing
3. **Edge case epochs**: When epochs have insufficient valid data points

The fix ensures plotting continues gracefully with sensible default ranges rather than crashing.

## Test plan
- [x] Manual testing with problematic dataset that triggered the error
- [x] Verified plotting continues with fallback ranges
- [x] Confirmed no regression in normal plotting scenarios
- [ ] Additional edge case testing with various data corruption scenarios

This resolves the immediate plotting crash and allows bidsify operations to complete successfully\! 📊