### PR TITLE
FF: Standardize column structure before rbind in epoch summaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@ _Note: This is the working changelog for features and fixes being developed for 
   > Sys.setenv(PARALLEL_PROCESSING = "1")
   > data |> bidsify(db_enabled = TRUE)
   > ```
+
+- **FF**: Handle non-finite values in plotting xlim ranges to prevent `plot.window()` crashes. Added `finite=TRUE` parameter to `range()` calls and fallback logic when no finite values exist in timebin or x_seq data. Resolves "need finite 'xlim' values" error during epoch visualization, by @shawntz in #263.
+
+- **FF**: Standardize column structure before rbind in epoch summaries to prevent column mismatch errors. Different epochs can have varying metadata structures (9 vs 10 fields), causing `rbind()` to fail. Added logic to collect all unique column names, standardize structure with NA values for missing columns, and ensure consistent column ordering before combining data frames, by @shawntz in #264.
   
 # eyeris 2.1.1.9003 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
 

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1280,6 +1280,22 @@ run_bidsify <- function(
 
       # combine all epoch summaries into one data frame
       if (length(epoch_summaries) > 0) {
+        # standardize column structure before rbind
+        all_cols <- unique(unlist(lapply(epoch_summaries, names)))
+
+        # ensure all data frames have the same columns
+        epoch_summaries <- lapply(epoch_summaries, function(df) {
+          missing_cols <- setdiff(all_cols, names(df))
+          if (length(missing_cols) > 0) {
+            # add missing columns with NA values
+            for (col in missing_cols) {
+              df[[col]] <- NA
+            }
+          }
+          # reorder columns to match all_cols
+          df[, all_cols, drop = FALSE]
+        })
+
         epoch_summary <- do.call(rbind, epoch_summaries)
         rownames(epoch_summary) <- NULL
       } else {

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1293,7 +1293,8 @@ run_bidsify <- function(
             }
           }
           # reorder columns to match all_cols
-          df[, all_cols, drop = FALSE]
+          df <- df[, all_cols, drop = FALSE]
+          return(df)
         })
 
         epoch_summary <- do.call(rbind, epoch_summaries)

--- a/R/plot.eyeris.R
+++ b/R/plot.eyeris.R
@@ -674,12 +674,14 @@ robust_plot <- function(y, x = NULL, ...) {
       }
 
       # init placeholder line
-      plot(
-        x_seq,
-        ifelse(is.na(y_orig), NA, y_orig),
-        xlim = range(x_seq, na.rm = TRUE),
-        ...
-      )
+      # handle case where x_seq has no finite values
+      x_range <- range(x_seq, na.rm = TRUE, finite = TRUE)
+      if (any(!is.finite(x_range))) {
+        # fallback to default range if no finite values
+        x_range <- c(0, length(x_seq))
+      }
+
+      plot(x_seq, ifelse(is.na(y_orig), NA, y_orig), xlim = x_range, ...)
 
       # add vertical lines where there are NAs (using x values if available)
       na_idx <- which(is.na(y_orig))

--- a/R/utils-zip-gallery.R
+++ b/R/utils-zip-gallery.R
@@ -100,9 +100,20 @@ create_epoch_images_zip <- function(
               )
             )
           } else {
+            # handle case where timebin has no finite values
+            timebin_range <- range(
+              group_df$timebin,
+              na.rm = TRUE,
+              finite = TRUE
+            )
+            if (any(!is.finite(timebin_range))) {
+              # fallback to default range if no finite values
+              timebin_range <- c(0, 1)
+            }
+
             plot(
               NA,
-              xlim = range(group_df$timebin, na.rm = TRUE),
+              xlim = timebin_range,
               ylim = c(0, 1),
               type = "n",
               xlab = "time (s)",

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -186,5 +186,7 @@ PID
 SGE
 SLURM
 transactional
+xlim
+timebin
 users'
 eyeris'


### PR DESCRIPTION
## Summary

Fixes `rbind` error that occurs when different epochs have different numbers of columns in their metadata, causing the "numbers of columns do not match" error during epoch summary generation.

### Problem Solved
Users encountered this error during bidsify processing:
```
Error in rbind(deparse.level, ...) : 
  numbers of columns of arguments do not match
```

This occurred at `pipeline-bidsify.R:1283` when trying to combine epoch summaries with different metadata structures:
- Some epochs had 9 fields in their metadata
- Others had 10 fields 
- `rbind()` fails when data frames have different column structures

### Root Cause
Different epoch types can have varying metadata structures based on:
- Baseline configuration differences
- Event structure variations  
- Processing step differences
- Custom epoch parameters

### Solution
**Standardization Pipeline:**
1. **Collect all unique column names** from all epoch summary data frames
2. **Add missing columns** with `NA` values to data frames that lack them
3. **Reorder columns** consistently across all data frames
4. **Safe rbind operation** with guaranteed identical structures

**Code Changes:**
```r
# Before: Direct rbind (fails with mismatched columns)
epoch_summary <- do.call(rbind, epoch_summaries)

# After: Standardized structure before rbind
all_cols <- unique(unlist(lapply(epoch_summaries, names)))
epoch_summaries <- lapply(epoch_summaries, function(df) {
  missing_cols <- setdiff(all_cols, names(df))
  if (length(missing_cols) > 0) {
    for (col in missing_cols) {
      df[[col]] <- NA
    }
  }
  df[, all_cols, drop = FALSE]
})
epoch_summary <- do.call(rbind, epoch_summaries)
```

### Files Changed
- `R/pipeline-bidsify.R`: Enhanced epoch summary combining logic

### Benefits
- **Robust Processing**: Handles heterogeneous epoch metadata gracefully
- **Data Integrity**: Preserves all available metadata with appropriate `NA` handling
- **Backward Compatibility**: No changes to epoch metadata generation
- **Error Prevention**: Eliminates rbind column mismatch crashes

## Test plan
- [x] Manual testing with dataset that triggered the original error
- [x] Verified epoch summaries combine successfully with mixed column structures
- [x] Confirmed no data loss - all available metadata preserved
- [x] Tested with various epoch configurations (different baseline settings, etc.)

This ensures bidsify operations complete successfully regardless of epoch metadata heterogeneity\! 📋