### PR TITLE
FF: better detection of grouping column for diagnostic plots in epoch preproc reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 2.1.1.9004
-Date: 2025-08-07
+Version: 2.1.1.9005
+Date: 2025-08-08
 Language: en-US
 Authors@R: 
   c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-# eyeris 2.1.1.9004 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
+# eyeris 2.1.1.9005 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
 
 ## ⚠ **development version** — unreleased
 
 _Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
+
+- **FF**: Intelligently detect grouping column for epoch diagnostic plots. For start/end epochs (e.g., `"PROBE_S {STIM}"` to `"PROBE_E {STIM}"`), the epoched data contains `start_matched_event` instead of `matched_event`. Added automatic detection logic with priority: requested column → `start_matched_event` → `end_matched_event`. Includes informative logging and graceful fallback when no suitable column found, by @shawntz.
 
 - **ENH**: Added parallel processing support for DuckDB database operations to prevent concurrency issues during batch processing. Implemented temporary database creation with automatic merging and cleanup mechanisms. Added environment variable detection for common HPC schedulers (SLURM, PBS, SGE, LSF) and manual `parallel_processing` parameter override. Includes comprehensive file locking, process/job ID logging, and full test coverage, by @shawntz in #262.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,13 @@
 
 _Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
 
-- **FF**: Intelligently detect grouping column for epoch diagnostic plots. For start/end epochs (e.g., `"PROBE_S {STIM}"` to `"PROBE_E {STIM}"`), the epoched data contains `start_matched_event` instead of `matched_event`. Added automatic detection logic with priority: requested column → `start_matched_event` → `end_matched_event`. Includes informative logging and graceful fallback when no suitable column found, by @shawntz.
+- **FF**: Intelligently detect grouping column for epoch diagnostic plots. For start/end epochs (e.g., `"PROBE_S {STIM}"` to `"PROBE_E {STIM}"`), the epoched data contains `start_matched_event` instead of `matched_event`. Added automatic detection logic with priority: requested column → `start_matched_event` → `end_matched_event`. Includes informative logging and graceful fallback when no suitable column found, by @shawntz in #265.
+
+# eyeris 2.1.1.9004 "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
+
+## ⚠ **development version** — unreleased
+
+_Note: This is the working changelog for features and fixes being developed for the next CRAN release (`v2.2.0`). Items will continue to be added here until that version is finalized._
 
 - **ENH**: Added parallel processing support for DuckDB database operations to prevent concurrency issues during batch processing. Implemented temporary database creation with automatic merging and cleanup mechanisms. Added environment variable detection for common HPC schedulers (SLURM, PBS, SGE, LSF) and manual `parallel_processing` parameter override. Includes comprehensive file locking, process/job ID logging, and full test coverage, by @shawntz in #262.
 

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1923,7 +1923,7 @@ run_bidsify <- function(
           # determine the appropriate grouping column for epoch diagnostics
           epoch_df <- epochs_to_save[[i]][[bn]]
           actual_grouping_col <- NULL
-          
+
           # check for the requested grouping column first
           if (report_epoch_grouping_var_col %in% colnames(epoch_df)) {
             actual_grouping_col <- report_epoch_grouping_var_col
@@ -1947,7 +1947,7 @@ run_bidsify <- function(
               "No suitable grouping column found for epoch '{names(epochs_to_save)[i]}' block '{bn}'. Skipping epoch diagnostic plots for this epoch.",
               verbose = verbose
             )
-            next  # skip epoch diagnostic plots for this epoch
+            next # skip epoch diagnostic plots for this epoch
           }
 
           # use run_num override for single block

--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -1920,17 +1920,35 @@ run_bidsify <- function(
             next
           }
 
-          tryCatch(
-            {
-              check_column(
-                epochs_to_save[[i]][[bn]],
-                report_epoch_grouping_var_col
-              )
-            },
-            error = function(e) {
-              error_handler(e, "column_doesnt_exist_in_df_error")
-            }
-          )
+          # determine the appropriate grouping column for epoch diagnostics
+          epoch_df <- epochs_to_save[[i]][[bn]]
+          actual_grouping_col <- NULL
+          
+          # check for the requested grouping column first
+          if (report_epoch_grouping_var_col %in% colnames(epoch_df)) {
+            actual_grouping_col <- report_epoch_grouping_var_col
+          } else if ("start_matched_event" %in% colnames(epoch_df)) {
+            # for start/end epochs, use start_matched_event
+            actual_grouping_col <- "start_matched_event"
+            log_info(
+              "Using 'start_matched_event' for epoch diagnostic plots (start/end epoch detected)",
+              verbose = verbose
+            )
+          } else if ("end_matched_event" %in% colnames(epoch_df)) {
+            # fallback to end_matched_event if start not available
+            actual_grouping_col <- "end_matched_event"
+            log_info(
+              "Using 'end_matched_event' for epoch diagnostic plots (start/end epoch detected)",
+              verbose = verbose
+            )
+          } else {
+            # no suitable grouping column found
+            log_warn(
+              "No suitable grouping column found for epoch '{names(epochs_to_save)[i]}' block '{bn}'. Skipping epoch diagnostic plots for this epoch.",
+              verbose = verbose
+            )
+            next  # skip epoch diagnostic plots for this epoch
+          }
 
           # use run_num override for single block
           run_dir_num <- if (!has_multiple_runs && !is.null(run_num)) {
@@ -1954,7 +1972,7 @@ run_bidsify <- function(
             pupil_steps = pupil_steps,
             eyeris_object = eyeris,
             eye_suffix = eye_suffix,
-            report_epoch_grouping_var_col = report_epoch_grouping_var_col,
+            report_epoch_grouping_var_col = actual_grouping_col,
             verbose = verbose
           )
 


### PR DESCRIPTION
## Summary

Fixes the "No grouping variable 'matched_event' in epoched df" error that occurs when using start/end epoch configurations (e.g., `"PROBE_S {STIM}"` to `"PROBE_E {STIM}"`).

### Problem Solved
When epoching with start and end events, the epoched data contains columns like:
- `start_matched_event` 
- `end_matched_event`
- `start_text_unique`, `end_text_unique`, etc.

But the epoch diagnostic plotting code was hardcoded to look for `matched_event` (which only exists for single-event epochs), causing the error and preventing diagnostic plot generation.

### Root Cause
Different epoch types create different column structures:
- **Single events**: `matched_event` column
- **Start/End events**: `start_matched_event` and `end_matched_event` columns

The `report_epoch_grouping_var_col` parameter defaults to `"matched_event"`, which doesn't exist in start/end epoch data.

### Solution
**Intelligent Column Detection:**
1. **Priority-based fallback logic**: 
   - First: Use requested `report_epoch_grouping_var_col` if it exists
   - Second: Fall back to `start_matched_event` for start/end epochs
   - Third: Fall back to `end_matched_event` if start not available
   - Last: Gracefully skip diagnostics if no suitable column found

2. **Informative logging**: Users are notified when fallback columns are used

3. **Backward compatibility**: Existing single-event epochs continue working unchanged

### Code Changes
```r
# Before: Hardcoded check for exact column
check_column(epochs_to_save[[i]][[bn]], report_epoch_grouping_var_col)

# After: Intelligent detection with fallbacks
if (report_epoch_grouping_var_col %in% colnames(epoch_df)) {
  actual_grouping_col <- report_epoch_grouping_var_col
} else if ("start_matched_event" %in% colnames(epoch_df)) {
  actual_grouping_col <- "start_matched_event"
} else if ("end_matched_event" %in% colnames(epoch_df)) {
  actual_grouping_col <- "end_matched_event"
}
```

### Files Changed
- `R/pipeline-bidsify.R`: Enhanced epoch diagnostic column detection logic
- `DESCRIPTION`: Version bump to 2.1.1.9005  
- `NEWS.md`: Changelog entry

### Benefits
- **Universal Compatibility**: Works with both single-event and start/end epoch configurations
- **Smart Defaults**: Automatically uses most appropriate grouping column
- **Graceful Degradation**: Skips diagnostics instead of crashing when no column available
- **Backward Compatibility**: No changes needed for existing single-event epoch workflows

## Test plan
- [x] Manual testing with start/end epochs (original error case)
- [x] Verified diagnostic plots generate correctly with `start_matched_event`
- [x] Confirmed no regression with standard single-event epochs
- [x] Tested graceful fallback when no suitable columns exist

This resolves the epoch diagnostic generation errors for start/end epoch configurations\! 📈