### PR TITLE
bug: Fix misleading `load_asc()` usage in database-guide documentation

### DIFF
--- a/R/pipeline-glassbox.R
+++ b/R/pipeline-glassbox.R
@@ -170,6 +170,19 @@ glassbox <- function(
     skip_detransient <- NULL
   }
 
+  # check if user accidentally passed an eyeris object instead of a file path
+  if (inherits(file, "eyeris")) {
+    log_error(
+      "You passed an eyeris object to glassbox(), but glassbox() expects a file path.\n\n",
+      "It looks like you may have called load_asc() first:\n",
+      "  eyeris_data <- load_asc('file.asc')\n",
+      "  glassbox(eyeris_data)  # <-- This causes an error\n\n",
+      "Instead, pass the file path directly to glassbox():\n",
+      "  'file.asc' %>% glassbox() %>% ...\n\n",
+      "The eyeris package handles .asc file reading internally."
+    )
+  }
+
   # the default glassbox pipeline parameters
   default_params <- list(
     load_asc = list(block = "auto", binocular_mode = "average"),

--- a/R/pipeline-glassbox.R
+++ b/R/pipeline-glassbox.R
@@ -172,15 +172,15 @@ glassbox <- function(
 
   # check if user accidentally passed an eyeris object instead of a file path
   if (inherits(file, "eyeris")) {
-    log_error(
+    log_error(paste0(
       "You passed an eyeris object to glassbox(), but glassbox() expects a file path.\n\n",
       "It looks like you may have called load_asc() first:\n",
       "  eyeris_data <- load_asc('file.asc')\n",
-      "  glassbox(eyeris_data)  # <-- This causes an error\n\n",
+      "  eyeris_data %>% glassbox()  # <-- This causes an error\n\n",
       "Instead, pass the file path directly to glassbox():\n",
       "  'file.asc' %>% glassbox() %>% ...\n\n",
       "The eyeris package handles .asc file reading internally."
-    )
+    ))
   }
 
   # the default glassbox pipeline parameters

--- a/vignettes/database-guide.Rmd
+++ b/vignettes/database-guide.Rmd
@@ -76,11 +76,9 @@ The `eyeris` package provides powerful database functionality that serves as an 
 The simplest way to create an `eyeris` database is by enabling database output during the `bidsify()` process:
 
 ```{r basic-creation}
-# load your EyeLink eye-tracking data ASC file
-eyeris_data <- load_asc("path/to/your/data.asc")
-
 # preprocess and epoch your data with eyeris glassbox functions
-processed_data <- eyeris_data %>%
+# Note: Pass the file path directly to glassbox() - eyeris handles .asc reading internally
+processed_data <- "path/to/your/data.asc" %>%
   glassbox() %>%
   epoch(
     events = "TRIAL_START_{trial_type}_{trial_number}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changelog entry

Fixed incorrect `load_asc()` usage pattern in database guide documentation (#287)

### Problem Addressed

Previously, the [Database Guide documentation](https://eyeris.shawnschwartz.com/articles/database-guide.html#getting-started-creating-your-first-eyeris-database) showed an incorrect usage pattern where users were instructed to call `load_asc()` first and then pipe the result into `glassbox()`:

```r
eyeris_data <- load_asc("path/to/your/data.asc")
processed_data <- eyeris_data %>%
  glassbox() %>%
  epoch(...)
```

This caused errors because `eyeris` expects a file path string to be passed directly into the pipeline, not an eyelinker object. The `load_asc()` function is handled internally by `eyeris` and should not be called directly by users.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)

The following changes are included in this patch release to correct the documentation and improve error handling:

1. **Updated the basic database creation example** to show the correct usage pattern where the file path is passed directly to `glassbox()`:
   ```r
   processed_data <- "path/to/your/data.asc" %>%
     glassbox() %>%
     epoch(...)
   ```

2. **Added a clarifying comment** explaining that `eyeris` handles `.asc` file reading internally, eliminating confusion about when `load_asc()` should be used.

3. **Removed the misleading `load_asc()` call** from the "Getting Started" section of the database guide.

4. **Added runtime error detection** in `glassbox()` to catch when users accidentally pass an eyeris object instead of a file path, with a helpful error message explaining the correct usage pattern.

### Acknowledgments

🙏 Thanks to @alicexue for reporting this issue and @shawntz for triaging it in #287.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://shawnschwartz.slack.com/archives/C0B7ZELCLN8/p1780456453710519?thread_ts=1780456453.710519&cid=C0B7ZELCLN8)

<div><a href="https://cursor.com/agents/bc-dc29e65e-b237-49e8-8b86-923f2da7f3db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc29e65e-b237-49e8-8b86-923f2da7f3db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

