### PR TITLE
docs: Add comprehensive example for loading custom data files

### DIFF
--- a/vignettes/complete-pipeline.Rmd
+++ b/vignettes/complete-pipeline.Rmd
@@ -122,9 +122,6 @@ my_data_path <- "/path/to/your/data/participant_01.asc"
 # Load the data file
 my_data <- eyeris::glassbox(my_data_path)
 
-# Or load it in two steps for more control
-my_data <- eyeris::load_asc(my_data_path, block = "auto")
-my_data_preprocessed <- eyeris::glassbox(my_data)
 ```
 
 **Important Notes:**

--- a/vignettes/complete-pipeline.Rmd
+++ b/vignettes/complete-pipeline.Rmd
@@ -110,7 +110,6 @@ The `.asc` file should be a standard EyeLink ASCII output file containing:
 
 - Sample data with timestamps, gaze coordinates (x, y), and pupil size
 - Event messages (e.g., `MSG` lines with trial markers, stimulus onsets)
-- Blink events detected by the eye tracker
 - Recording metadata (sample rate, pupil measurement type, etc.)
 
 **Example Code for Loading Custom Data:**
@@ -121,7 +120,6 @@ my_data_path <- "/path/to/your/data/participant_01.asc"
 
 # Load the data file
 my_data <- eyeris::glassbox(my_data_path)
-
 ```
 
 **Important Notes:**

--- a/vignettes/complete-pipeline.Rmd
+++ b/vignettes/complete-pipeline.Rmd
@@ -89,12 +89,85 @@ library(eyeris)
 
 ### Loading Your Raw Data
 
+#### Using the Demo Dataset
+
 For this demo, we'll use our built in demo dataset, which contains a handful of
 trials from an associative memory task recorded in our lab.
 
 ```{r load-data}
 demo_data <- eyelink_asc_demo_dataset()
 ```
+
+#### Loading Your Own Custom Data
+
+To load your own EyeLink pupillometry data, you need an `.asc` file converted 
+from your original `.edf` file using the official EyeLink `edf2asc` command-line 
+utility provided by SR Research.
+
+**Expected Data Format:**
+
+The `.asc` file should be a standard EyeLink ASCII output file containing:
+
+- Sample data with timestamps, gaze coordinates (x, y), and pupil size
+- Event messages (e.g., `MSG` lines with trial markers, stimulus onsets)
+- Blink events detected by the eye tracker
+- Recording metadata (sample rate, pupil measurement type, etc.)
+
+**Example Code for Loading Custom Data:**
+
+```{r load-custom-data, eval=FALSE}
+# Point to your own .asc file
+my_data_path <- "/path/to/your/data/participant_01.asc"
+
+# Load the data file
+my_data <- eyeris::glassbox(my_data_path)
+
+# Or load it in two steps for more control
+my_data <- eyeris::load_asc(my_data_path, block = "auto")
+my_data_preprocessed <- eyeris::glassbox(my_data)
+```
+
+**Important Notes:**
+
+- **File Path**: Replace `"/path/to/your/data/participant_01.asc"` with the 
+  actual path to your `.asc` file.
+
+- **Block Handling**: Use `block = "auto"` (default) to automatically detect 
+  multiple recording segments within the same file. This is recommended for 
+  most use cases. See `?eyeris::load_asc` for other options.
+
+- **Binocular Data**: If you have binocular recordings, you can specify how 
+  to handle them:
+  ```{r binocular-example, eval=FALSE}
+  # Average both eyes (default)
+  my_data <- eyeris::glassbox(
+    my_data_path,
+    load_asc = list(binocular_mode = "average")
+  )
+  
+  # Use only left eye
+  my_data <- eyeris::glassbox(
+    my_data_path,
+    load_asc = list(binocular_mode = "left")
+  )
+  
+  # Use only right eye
+  my_data <- eyeris::glassbox(
+    my_data_path,
+    load_asc = list(binocular_mode = "right")
+  )
+  
+  # Process both eyes independently
+  my_data <- eyeris::glassbox(
+    my_data_path,
+    load_asc = list(binocular_mode = "both")
+  )
+  ```
+
+- **Data Quality**: Ensure your data was recorded **without** online filtering 
+  applied by the EyeLink Host PC. The `eyeris` pipeline expects raw, unfiltered 
+  data. See the [Caveats](#caveats) section below for more details on this critical 
+  requirement.
 
 ### Running the Fully-Automated Pipeline
 


### PR DESCRIPTION
## Changelog entry

Documentation enhancement: Added custom data loading guidance in the complete pipeline vignette, and removed an invalid two-step example.

### Problem Addressed

Previously, the <a href="https://eyeris.shawnschwartz.com/articles/complete-pipeline.html#loading-your-raw-data">Loading Your Raw Data</a> section of the Complete Pipeline documentation only demonstrated loading the built-in demo data. Users who wanted to load their own custom data had no practical example to follow, creating a significant gap for new users trying to get started with real-world datasets.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)

The following documentation improvements are included in this patch release:

1. **Added "Loading Your Own Custom Data" subsection** with clear structure distinguishing demo data usage from custom data workflows.
2. **Documented expected data format and requirements** including the need for `.asc` files converted from `.edf` using the official EyeLink `edf2asc` utility.
3. **Provided practical code examples** showing:
   - Basic custom data loading with file path placeholder
   - Binocular data handling options (average, left, right, both)
4. **Added important notes** covering:
   - File path specification
   - Block handling recommendations
   - Binocular mode options
   - Data quality requirements (referencing existing Caveats section)
5. **Cross-referenced existing documentation** to guide users to the Caveats section for critical information about online filtering warnings.
6. **Corrected the custom data example** by removing an invalid two-step `load_asc()` + `glassbox()` snippet that would fail `glassbox` input guards.

### Acknowledgments

🙏 Thanks to @alicexue for reporting this issue and @shawntz for triaging it in https://github.com/shawntz/eyeris/issues/289.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md