### PR TITLE
Fix: Downsampled epoch data compressed in HTML plot

### DIFF
--- a/R/pipeline-epoch.R
+++ b/R/pipeline-epoch.R
@@ -375,7 +375,13 @@ epoch_pupil <- function(
   start_time <- Sys.time()
 
   if (is.null(hz)) {
-    hz <- x$info$sample.rate
+    # use decimated sample rate if available (after downsample/bin),
+    # otherwise use original sample rate
+    hz <- if (!is.na(x$decimated.sample.rate)) {
+      x$decimated.sample.rate
+    } else {
+      x$info$sample.rate
+    }
   }
 
   msg_s <- evs[1]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changelog entry

Fixed downsampled epoch data being visually compressed in HTML plots (#291)

### Problem Addressed

Previously, when downsampling was enabled in the Glassbox pipeline, the generated HTML plots showed 5-second epochs compressed to only 0.5 seconds visually, even though the x-axis labels and CSV output were correct. This created a 10x compression factor that made it appear as if data was only rendered for the first ~0.5 seconds of each 5-second epoch window.

The root cause was that the epoch timebin calculation in `pipeline-epoch.R` used the original sampling rate (`info$sample.rate`) instead of the decimated sampling rate (`decimated.sample.rate`) when downsampling was applied. This meant that a 5-second epoch with 500 samples at 100Hz was being calculated as `500/1000 = 0.5s` instead of `500/100 = 5s`.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)

The following changes are included in this patch release to fix the plotting/rendering bug:

1. **Updated `epoch_pupil()` function** to check for `decimated.sample.rate` first before falling back to the original `info$sample.rate` when calculating the `hz` parameter used for epoch timebin generation.
2. **Added explanatory comment** to clarify the logic for future maintainers.

This ensures that when downsampling or binning operations are applied, the epoch plots correctly display the full duration of each epoch window.

### Acknowledgments

🙏 Thanks to @alicexue for reporting this issue in #291.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://shawnschwartz.slack.com/archives/C0B8RN7DMDE/p1780503904562729?thread_ts=1780503904.562729&cid=C0B8RN7DMDE)

<div><a href="https://cursor.com/agents/bc-2955ee08-f4e3-522a-a60f-d8912a90c4ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2955ee08-f4e3-522a-a60f-d8912a90c4ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

