### PR TITLE
docs: note EyeLink-only support, format roadmap, and contribution path (#301)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -59,6 +59,35 @@ coordinates across the entire screen area, helping you assess data quality
 and participant attention patterns. These heatmaps are automatically generated 
 in the BIDS reports and can also be created manually.
 
+<div class="alert alert-light">
+
+### 👁 Supported eye-tracker formats
+
+The current version of `eyeris` reads data recorded with **SR Research
+EyeLink** eye-trackers (via the `.asc` files produced by EyeLink's
+`edf2asc` converter). EyeLink remains the most widely used research-grade
+system in the pupillometry community, so we focused our initial efforts
+there to ensure a robust, well-tested foundation.
+
+That said, `eyeris` is designed from the ground up to be **format-agnostic
+downstream of data loading**: every preprocessing step operates on a
+standardized internal `eyeris` object rather than on raw EyeLink files.
+This means support for additional open-source and vendor eye-tracker
+formats (e.g., Pupil Labs, Tobii, GazePoint, and the emerging
+[BIDS Eye Tracking](https://bids.neuroimaging.io/) specification) can be
+added by writing a new data-loading function that maps raw samples and
+event messages onto the same internal representation — no changes to the
+preprocessing pipeline are required.
+
+**Roadmap & community contributions.** Broadening native support for other
+tracker formats is on our roadmap, and we actively welcome community
+contributions of new loaders. If you would like to help add support for
+your tracker of choice, please open an issue or pull request — see the
+[contribution guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html)
+to get started.
+
+</div>
+
 ## 🚀 Feature Highlights
 
 - `📦 Modular Design`: Each preprocessing step is a standalone function that can be used independently or combined into custom pipelines.

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,7 +64,7 @@ in the BIDS reports and can also be created manually.
 ### 👁 Supported eye-tracker formats
 
 The current version of `eyeris` reads data recorded with **SR Research
-EyeLink** eye-trackers (via the `.asc` files produced by EyeLink's
+EyeLink** eye-trackers (via the `.asc` files produced by the EyeLink
 `edf2asc` converter). EyeLink remains the most widely used research-grade
 system in the pupillometry community, so we focused our initial efforts
 there to ensure a robust, well-tested foundation.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,36 @@ quality and participant attention patterns. These heatmaps are
 automatically generated in the BIDS reports and can also be created
 manually.
 
+<div class="alert alert-light">
+
+### 👁 Supported eye-tracker formats
+
+The current version of `eyeris` reads data recorded with **SR Research
+EyeLink** eye-trackers (via the `.asc` files produced by EyeLink’s
+`edf2asc` converter). EyeLink remains the most widely used research-grade
+system in the pupillometry community, so we focused our initial efforts
+there to ensure a robust, well-tested foundation.
+
+That said, `eyeris` is designed from the ground up to be
+**format-agnostic downstream of data loading**: every preprocessing step
+operates on a standardized internal `eyeris` object rather than on raw
+EyeLink files. This means support for additional open-source and vendor
+eye-tracker formats (e.g., Pupil Labs, Tobii, GazePoint, and the
+emerging [BIDS Eye Tracking](https://bids.neuroimaging.io/)
+specification) can be added by writing a new data-loading function that
+maps raw samples and event messages onto the same internal
+representation — no changes to the preprocessing pipeline are required.
+
+**Roadmap & community contributions.** Broadening native support for
+other tracker formats is on our roadmap, and we actively welcome
+community contributions of new loaders. If you would like to help add
+support for your tracker of choice, please open an issue or pull
+request — see the [contribution
+guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html) to get
+started.
+
+</div>
+
 ## 🚀 Feature Highlights
 
 - `📦 Modular Design`: Each preprocessing step is a standalone function

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ manually.
 ### 👁 Supported eye-tracker formats
 
 The current version of `eyeris` reads data recorded with **SR Research
-EyeLink** eye-trackers (via the `.asc` files produced by EyeLink’s
+EyeLink** eye-trackers (via the `.asc` files produced by the EyeLink
 `edf2asc` converter). EyeLink remains the most widely used research-grade
 system in the pupillometry community, so we focused our initial efforts
 there to ensure a robust, well-tested foundation.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -209,3 +209,8 @@ eyeris'
 CRAN's
 GIFs
 pandoc
+GazePoint
+Tobii
+Labs
+edf2asc
+loaders

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -214,3 +214,5 @@ Tobii
 Labs
 edf2asc
 loaders
+roadmap
+Roadmap


### PR DESCRIPTION
## Summary

Addresses #301 by documenting in the README that the current version of `eyeris` supports SR Research EyeLink data, and outlining the roadmap for interfacing with other eye-tracker formats.

Adds a **"👁 Supported eye-tracker formats"** callout (in both `README.Rmd` and the generated `README.md`) just after the Motivation section. It:

- Notes current **EyeLink `.asc` support** and the rationale (most widely used research-grade system).
- Explains that `eyeris` is **format-agnostic downstream of data loading** — every preprocessing step operates on a standardized internal `eyeris` object, so new formats only require a new loader.
- Names concrete forward-looking targets: **Pupil Labs, Tobii, GazePoint, and the BIDS Eye Tracking spec**.
- Frames this as a known limitation with a clear **roadmap** and an explicit **community-contribution path** (open an issue/PR; links contribution guidelines).

Also adds `GazePoint`, `Tobii`, `Labs`, `edf2asc`, and `loaders` to `inst/WORDLIST` so the spellcheck CI job passes.

## Acceptance criteria

- [x] README note on current EyeLink support + extensibility
- [ ] Manuscript footnote 4 updated to reference forward-looking format support — _not in this repo; lives in the bioRxiv/Overleaf preprint and must be updated there._
- [x] Mention community-contribution path for new tracker formats

## Notes

`README.md` was edited by hand to stay in sync with `README.Rmd` rather than re-knitting, since a full render would execute the data-loading/`glassbox` code chunks. Happy to regenerate via `devtools::build_readme()` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information on supported eye-tracker formats, currently including SR Research EyeLink (.asc files)
  * Documented the format-agnostic design approach for eye-tracker data integration
  * Added references to contribution guidelines and roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->