### PR TITLE
Bump development version to 3.1.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 3.1.0
+Version: 3.1.0.9000
 Date: 2026-06-05
 Language: en-US
 Authors@R: 


### PR DESCRIPTION
Bumps the package version in `DESCRIPTION` from `3.1.0` to `3.1.0.9000` to mark the start of development on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)