### PR TITLE
Fix pkgdown build: drop print.eyeris_boilerplate from reference index

### DIFF
--- a/R/utils-boilerplate.R
+++ b/R/utils-boilerplate.R
@@ -103,6 +103,8 @@ boilerplate <- function(
 #'
 #' @return The input `x`, invisibly
 #'
+#' @keywords internal
+#'
 #' @export
 print.eyeris_boilerplate <- function(x, ...) {
   cat(unclass(x))

--- a/man/print.eyeris_boilerplate.Rd
+++ b/man/print.eyeris_boilerplate.Rd
@@ -18,3 +18,4 @@ The input \code{x}, invisibly
 Renders the Markdown boilerplate text to the console as-is (rather than as a
 single escaped string).
 }
+\keyword{internal}


### PR DESCRIPTION
## Problem

The pkgdown site build (and the GitHub Actions docs job) was failing:

```
✖ Reference metadata not ok.
  In _pkgdown.yml, 1 topic missing from index: "print.eyeris_boilerplate".
  Either add to the reference index, or use `@keywords internal` to drop from
  the index.
...
Error in `build_reference_index()`:
! In _pkgdown.yml, 1 topic missing from index:
  "print.eyeris_boilerplate".
```

The exported S3 method `print.eyeris_boilerplate` had no corresponding entry in the `_pkgdown.yml` reference index, so `build_reference_index()` aborted.

## Fix

Marked `print.eyeris_boilerplate` with `@keywords internal` in `R/utils-boilerplate.R` and regenerated `man/print.eyeris_boilerplate.Rd`.

S3 print methods need `@export` for dispatch but should not surface as standalone reference topics. `@keywords internal` keeps the method exported while dropping it from the pkgdown index — consistent with how the other internal helpers in this file are already documented.

## Verification

`pkgdown:::data_reference_index()` now passes the missing-topics check (it only stops later on a local "Pandoc not available" environment limitation, unrelated to this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation metadata to mark internal components appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->