### PR TITLE
Fix missing versions in pkgdown navbar dropdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,9 +4,13 @@ news:
     cran_dates: true
     releases:
     - text: "LATEST STABLE RELEASE"
+    - text: "v3.1.0 (CRAN)"
+      href: news/index.html#eyeris-310-lumpy-space-princess-lumpy-space-princess
+    - text: -------
+    - text: "v3.2.0 (pre-release)"
+      href: news/index.html#eyeris-320-pre-release-lumpy-space-princess-lumpy-space-princess
     - text: "v3.0.1 (CRAN)"
       href: news/index.html#eyeris-301-lumpy-space-princess-lumpy-space-princess
-    - text: -------
     - text: "v3.0.0 (CRAN)"
       href: news/index.html#eyeris-300-lumpy-space-princess-lumpy-space-princess
     - text: "Previous Releases"


### PR DESCRIPTION
## Summary

The releases dropdown in the pkgdown navbar header (`_pkgdown.yml`) was missing entries for two versions that already exist in `NEWS.md`:

- **v3.1.0 (CRAN)** — the current latest stable release (tagged `v3.1.0`)
- **v3.2.0 (pre-release)** — the upcoming dev release

## Changes

- Promote **v3.1.0 (CRAN)** to the `LATEST STABLE RELEASE` slot (was stuck on v3.0.1)
- Add the **v3.2.0 (pre-release)** entry
- Each links to its generated anchor under `news/index.html`

## Notes

Anchors follow the existing pkgdown slug pattern derived from the NEWS headers (e.g. `eyeris-310-lumpy-space-princess-lumpy-space-princess`, `eyeris-320-pre-release-lumpy-space-princess-lumpy-space-princess`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated release listings to promote v3.1.0 as the latest stable version and added v3.2.0 pre-release information to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->