### PR TITLE
Summarize all v3.2.0 changes in NEWS.md intro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # eyeris 3.2.0 (pre-release) "Lumpy Space Princess" ![Lumpy Space Princess](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/inst/figures/adventure-time/lsp.png){width="50"}
 
-This patch release fixes a report/figure collision that occurred when different task names shared the same run number within a subject/session.
+This release fixes several correctness and data-integrity bugs and adds new transparency and reproducibility tooling. Bug fixes resolve a report/figure collision when different task names shared the same run number within a subject/session, misleading diagnostic plots for pipeline steps that precede downsampling/binning, and silent data loss in `eyeris_db_read()`/`eyeris_db_collect()` when table schemas diverged across `eyeris` versions. New features add a "percent data lost" annotation to the HTML report, expose a `prop_missing`/`n_missing` missing-data column at the block and trial levels for user-defined filtering, and introduce `boilerplate()`, an fMRIPrep-style generator that auto-writes copy-and-paste-ready methods text from the parameters captured in your pipeline. Documentation now cross-references every modular preprocessing function to a complete end-to-end reference pipeline.
 
 ## 🐛 Bugs fixed
 


### PR DESCRIPTION
## Summary

The v3.2.0 intro sentence in `NEWS.md` only described the #293 report/figure collision fix, even though the section also documents two other bug fixes, three new features, and a documentation change. This replaces that one-issue sentence with a summary that accurately reflects everything in the v3.2.0 section:

- **Bug fixes**: report/figure collision across same-numbered runs (#293), misleading diagnostic plots before downsampling/binning (#294), and silent data loss in `eyeris_db_read()`/`eyeris_db_collect()` on divergent schemas (#310).
- **New features**: "percent data lost" report annotation (#296), `prop_missing`/`n_missing` missing-data columns for user-defined filtering (#297), and the `boilerplate()` fMRIPrep-style methods generator (#302).
- **Documentation**: cross-references from every modular preprocessing function to a complete end-to-end reference pipeline (#298).

🤖 Generated with [Claude Code](https://claude.com/claude-code)