### PR TITLE
docs: add recalibration to spell check wordlist

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -132,6 +132,7 @@ Pupillometry
 Purdon
 RColorBrewer
 README
+recalibration
 reimplementing
 repo
 reproducibility


### PR DESCRIPTION
Adds the word `recalibration` to `inst/WORDLIST` so spell check (R CMD check) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)