### PR TITLE
docs: anonymize demo data in multiple-runs-separate-files vignette

### DIFF
--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -58,7 +58,7 @@ to `bidsify()`.
 
 ## The pattern
 
-Suppose participant `AM22` completed three runs of an associative-memory task,
+Suppose participant `AB01` completed three runs of an associative-memory task,
 each saved to its own file:
 
 ```{r eval=FALSE}
@@ -66,9 +66,9 @@ library(eyeris)
 
 dl <- path.expand("~/Downloads")
 asc_files <- file.path(dl, c(
-  "sub-AM22_t1_2026-03-09_20h46.11.141.asc",
-  "sub-AM22_t2_2026-03-09_21h08.15.079.asc",
-  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"
+  "sub-AB01_t1_2024-01-15_10h00.00.000.asc",
+  "sub-AB01_t2_2024-01-15_10h30.00.000.asc",
+  "sub-AB01_t3_2024-01-15_11h00.00.000.asc"
 ))
 stopifnot(all(file.exists(asc_files)))
 
@@ -83,7 +83,7 @@ for (i in seq_along(asc_files)) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -126,19 +126,19 @@ shown for `run-01`; `run-02` and `run-03` follow the same pattern):
 ```
 eyeris
 └── derivatives
-    └── sub-AM22
+    └── sub-AB01
         └── ses-01
             ├── eye
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-timeseries.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-blinks.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-events.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-epoch_summary.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-preproc_pupil_epoch-trialepochs.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-blinks.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-events.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-epoch_summary.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-preproc_pupil_epoch-trialepochs.csv
             │   ├── epoch_trialEpochs/   # per-trial confounds CSVs for run-01
             │   │   └── ...
-            │   ├── sub-AM22_ses-01_task-assocmem_run-02_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-02_desc-timeseries.csv
             │   ├── ...
-            │   ├── sub-AM22_ses-01_task-assocmem_run-03_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-03_desc-timeseries.csv
             │   └── ...
             ├── source
             │   ├── figures
@@ -152,14 +152,14 @@ eyeris
             │       ├── task-assocmem_run-01_metadata.json
             │       ├── task-assocmem_run-02_metadata.json
             │       └── task-assocmem_run-03_metadata.json
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-01.html
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-02.html
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-03.html
-            └── sub-AM22_task-assocmem.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-01.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-02.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-03.html
+            └── sub-AB01_task-assocmem.html
 ```
 
 Every data file carries its `run-<index>`, and the top-level
-`sub-AM22_task-assocmem.html` report aggregates all three runs. For a full
+`sub-AB01_task-assocmem.html` report aggregates all three runs. For a full
 breakdown of what each derivative file contains, see the
 [Extracting Data Epochs and Exporting Pupil Data](epoching-bids-reports.html)
 vignette.
@@ -196,8 +196,8 @@ position. Two robust options:
 
 ```{r eval=FALSE}
 asc_files <- file.path(dl, c(
-  "sub-AM22_t1_2026-03-09_20h46.11.141.asc", # run 1
-  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"  # run 3 (run 2 not collected)
+  "sub-AB01_t1_2024-01-15_10h00.00.000.asc", # run 1
+  "sub-AB01_t3_2024-01-15_11h00.00.000.asc"  # run 3 (run 2 not collected)
 ))
 run_nums <- c(1, 3) # the TRUE run numbers, in the same order as `asc_files`
 
@@ -210,7 +210,7 @@ for (i in seq_along(asc_files)) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -236,7 +236,7 @@ for (f in asc_files) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -272,7 +272,7 @@ glassbox(asc_files[2], load_asc = list(block = 2), verbose = TRUE) |>
   ) |>
   bidsify(
     bids_dir       = output_dir,
-    participant_id = "AM22",
+    participant_id = "AB01",
     session_num    = "01",
     task_name      = "assocmem",
     save_raw       = TRUE,
@@ -329,7 +329,7 @@ glassbox(one_file_with_all_runs, load_asc = list(block = "auto")) |>
   ) |>
   bidsify(
     bids_dir       = output_dir,
-    participant_id = "AM22",
+    participant_id = "AB01",
     session_num    = "01",
     task_name      = "assocmem"
   )


### PR DESCRIPTION
## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
Anonymized demo data (participant ID and `.asc` filenames) in the "Preprocessing multiple runs saved in separate files" vignette.

### Problem Addressed
> The `multiple-runs-separate-files` vignette used a real participant ID (`AM22`) and real EyeLink `.asc` filenames containing real acquisition timestamps, exposing identifiable demo data in the published docs.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)
> 1. **Replaced the subject ID `AM22` with a fake ID `AB01`** throughout the vignette — prose, `participant_id` arguments, the BIDS output tree, and HTML report filenames.
> 2. **Replaced the real `.asc` demo filenames** (with real timestamps) with made-up filenames using generic dates/times.
> 3. **Preserved the `_t{n}_` run-number pattern** in the filenames so the run-parsing regex example (`sub(".*_t(\\d+)_.*", ...)`) still works as documented.

### Acknowledgments
> 🙏 Thanks to @shawntz for flagging the identifiable demo data.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the worked example to use participant `AB01` throughout.
  * Aligned example filenames, output paths, and report names with the new participant ID.
  * Refreshed the “missing or non-sequential runs,” “re-running a single run,” and “multiple runs inside one file” examples for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->