### PR TITLE
docs: document bridge function for non-auto-separated multi-block data

### DIFF
--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -336,9 +336,16 @@ glassbox(one_file_with_all_runs, load_asc = list(block = "auto")) |>
 ```
 
 Here `block = "auto"` (the default) detects each recording segment and numbers
-them `run-01`, `run-02`, … from their embedded block numbers. See the
+them `run-01`, `run-02`, … from their embedded block numbers.[^bridge] See the
 [Complete Pipeline](complete-pipeline.html) and
 [Anatomy of an `eyeris` Object](anatomy.html) vignettes for more on that path.
+
+[^bridge]: If a user supplies multi-block data that is not automatically
+separated by common start/stop recording indicators, we recommend the user to
+manually cut the data into multiple files (by block). `eyeris` supplies a bridge
+function that enables users to pass generic tabular eye-tracking data in case of
+situations like this and/or for trackers that are not natively supported by
+`eyeris` at the time of processing.
 
 ## ✨ Summary
 


### PR DESCRIPTION
## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
Added a footnote to the "Preprocessing Multiple Runs Stored in Separate Files" vignette documenting the bridge function for generic tabular eye-tracking data.

### Problem Addressed
> The multiple-runs vignette explained `eyeris`'s automatic segment detection (`block = "auto"`) but gave no guidance for users whose multi-block data is *not* automatically separated by common start/stop recording indicators, or who use trackers not natively supported by `eyeris`.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)
> 1. **Added a footnote** in `vignettes/multiple-runs-separate-files.Rmd`, anchored to the `block = "auto"` explanation, recommending users manually cut non-auto-separated data into per-block files and noting that `eyeris` supplies a bridge function for passing generic tabular eye-tracking data (also useful for unsupported trackers).

### Acknowledgments
> Docs-only change.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance in the vignette for handling multi-run data stored in a single file.
  * Added a note explaining when a bridge-style workflow may be needed for data that is not automatically split by standard run markers.
  * Kept the existing explanation for naming runs consistently while linking it to the new note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->