### PR TITLE
chore: bump version to 3.2.0.9001

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 3.2.0.9000
+Version: 3.2.0.9001
 Date: 2026-06-24
 Language: en-US
 Authors@R: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# eyeris 3.2.0.9000 (development version)
+# eyeris 3.2.0.9001 (development version)
 
 ## 🐛 Bugs fixed
 


### PR DESCRIPTION
## Changelog entry

Bumped development version to `3.2.0.9001`.

### Problem Addressed
The development version needed to be incremented to mark a new development cycle following `3.2.0.9000`.

### Key Changes and Enhancements (Targeting `v3.2.0.9001` [`Patch`] Release)

1. Bumped `Version` in `DESCRIPTION` from `3.2.0.9000` to `3.2.0.9001`.
2. Updated the development version header in `NEWS.md` to match.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [x] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app/package version to the next development release.
* **Documentation**
  * Reflected the new development version in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->