### PR TITLE
fix: honor run_num override for epoch CSVs and per-run metadata

### DIFF
--- a/R/pipeline-bidsify.R
+++ b/R/pipeline-bidsify.R
@@ -420,6 +420,13 @@ run_bidsify <- function(
           current_block_names[
             current_block_names == original_block_name
           ] <- new_block_name
+          # write the renamed block key back onto the epoch list. without this
+          # the rename lived only in the local `current_block_names` copy, so
+          # the epoch element stayed keyed to the original block (e.g.
+          # "block_1"), the `eyeris[[epoch_name]][[new_block_name]]` update
+          # below silently no-op'd, and every single-run `run_num` override
+          # collapsed its epoch CSV onto run-01 (last-run-wins overwrite).
+          names(eyeris[[epoch_name]]) <- current_block_names
 
           if (!is.null(epoch_info)) {
             names(epoch_info)[

--- a/R/utils-render_report.R
+++ b/R/utils-render_report.R
@@ -206,31 +206,47 @@ make_report <- function(eyeris, out, plots, eye_suffix = NULL, ...) {
   logs_dir <- file.path(out, "source", "logs")
   callstack_md <- ""
 
+  # only (re)generate a run's metadata.json for the run(s) actually present in
+  # the eyeris object being processed. when separate single-run files are
+  # bidsified into a shared bids_dir (each with its own `run_num`), the
+  # figures/ dir accumulates run directories from earlier iterations, so
+  # `run_ids` (scanned from disk) enumerates those sibling runs too. without
+  # this guard, each sibling's metadata would be rewritten from the current
+  # in-memory object, clobbering its real source_file/call_stack with the
+  # latest run's.
+  current_run_ids <- tryCatch(
+    as.integer(get_block_numbers(eyeris)),
+    error = function(e) run_ids
+  )
+
   for (run_id in run_ids) {
     metadata_dir <- file.path(out, "source", "logs")
     if (!dir.exists(metadata_dir)) {
       dir.create(metadata_dir, recursive = TRUE)
     }
 
-    run_metadata <- list(
-      run = run_id,
-      source_file = eyeris$file,
-      call_stack = sanitize_call_stack(eyeris$params)
-    )
-
     meta_path <- file.path(
       metadata_dir,
       sprintf("%s_metadata.json", make_run_dir_name(run_id, task))
     )
 
-    # Always regenerate metadata to ensure it uses the latest sanitization
-    # This prevents issues with old files containing huge epoch data
-    jsonlite::write_json(
-      run_metadata,
-      meta_path,
-      pretty = TRUE,
-      auto_unbox = TRUE
-    )
+    # Regenerate metadata for the current run(s) to ensure it uses the latest
+    # sanitization (prevents old files containing huge epoch data). Sibling
+    # runs written in earlier iterations keep their already-correct metadata.
+    if (run_id %in% current_run_ids) {
+      run_metadata <- list(
+        run = run_id,
+        source_file = eyeris$file,
+        call_stack = sanitize_call_stack(eyeris$params)
+      )
+
+      jsonlite::write_json(
+        run_metadata,
+        meta_path,
+        pretty = TRUE,
+        auto_unbox = TRUE
+      )
+    }
 
     if (file.exists(meta_path)) {
       meta <- jsonlite::read_json(meta_path)

--- a/tests/testthat/test-bidsify-runnum-override.R
+++ b/tests/testthat/test-bidsify-runnum-override.R
@@ -1,0 +1,142 @@
+# Regression tests for the single-run `run_num`-override bug:
+# "separate single-block .asc files bidsified into a shared bids_dir with a
+#  per-file run_num override overwrite each other's epoch CSV and metadata"
+#
+# Workflow that triggered it (one .asc per run, looped into one bids_dir):
+#
+#   for (i in seq_along(asc_files))
+#     glassbox(asc_files[i]) |> epoch(...) |> bidsify(run_num = i, ...)
+#
+# load_asc() always keys a single-file object as "block_1", so bidsify()
+# renames that block to "block_<run_num>" when a run_num override is supplied.
+# Two defects broke that rename for a subset of outputs:
+#
+#   1. .bidsify() renamed the epoch block only in a *local copy* of the
+#      block-name vector and never assigned it back onto the epoch list, so the
+#      epoch element stayed keyed to "block_1". The single-run epoch writer
+#      derived its run number from that key, so every run's
+#      `..._desc-preproc_pupil_epoch-<label>.csv` collapsed onto run-01
+#      (last-run-wins overwrite).
+#
+#   2. make_report() enumerated run directories from disk (which accumulate
+#      across loop iterations sharing one bids_dir) and regenerated *every*
+#      run's `<run>_metadata.json` from the current in-memory object, clobbering
+#      each earlier run's source_file/call_stack with the latest run's.
+
+# Copy the single-block demo into `n` distinct .asc files so each loop
+# iteration has its own source path (mirrors real separate-run recordings).
+copy_demo_runs <- function(n) {
+  demo <- eyelink_asc_demo_dataset()
+  dir <- tempfile("runnum_srcs_")
+  dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  paths <- file.path(dir, sprintf("sub-AM22_t%d.asc", seq_len(n)))
+  file.copy(demo, paths)
+  paths
+}
+
+bidsify_run <- function(asc, bids_dir, run_num, html_report = FALSE) {
+  glassbox(asc, verbose = FALSE) |>
+    epoch(
+      events = "PROBE_{type}_{trial}",
+      limits = c(-1, 1),
+      label = "trialEpochs",
+      verbose = FALSE
+    ) |>
+    bidsify(
+      bids_dir = bids_dir,
+      run_num = run_num,
+      participant_id = "AM22",
+      session_num = "01",
+      task_name = "assocmem",
+      save_raw = TRUE,
+      html_report = html_report,
+      verbose = FALSE
+    )
+}
+
+test_that("single-run run_num override writes a distinct epoch CSV per run", {
+  skip_on_cran()
+
+  asc_files <- copy_demo_runs(3)
+  on.exit(unlink(dirname(asc_files[1]), recursive = TRUE), add = TRUE)
+
+  bids_dir <- tempfile("bids_runnum_epoch_")
+  dir.create(bids_dir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+
+  for (i in seq_along(asc_files)) {
+    bidsify_run(asc_files[i], bids_dir, run_num = i, html_report = FALSE)
+  }
+
+  deriv <- file.path(bids_dir, "derivatives", "sub-AM22", "ses-01")
+  all_files <- list.files(deriv, recursive = TRUE)
+
+  # the epoch label is lowercased by sanitize_event_tag() on its way to disk
+  epoch_csvs <- grep(
+    "desc-preproc_pupil_epoch-trialepochs\\.csv$",
+    all_files,
+    value = TRUE
+  )
+
+  # one preproc_pupil epoch CSV per run_num, none collapsed onto run-01
+  expect_true(any(grepl("run-01_desc-preproc_pupil_epoch-", epoch_csvs)))
+  expect_true(any(grepl("run-02_desc-preproc_pupil_epoch-", epoch_csvs)))
+  expect_true(any(grepl("run-03_desc-preproc_pupil_epoch-", epoch_csvs)))
+  expect_length(unique(epoch_csvs), 3)
+
+  # the in-file `block` column tracks the override too (not stuck at 1)
+  read_block <- function(rn) {
+    f <- file.path(
+      deriv,
+      "eye",
+      sprintf(
+        "sub-AM22_ses-01_task-assocmem_run-%s_desc-preproc_pupil_epoch-trialepochs.csv",
+        rn
+      )
+    )
+    unique(utils::read.csv(f)$block)
+  }
+  expect_equal(read_block("01"), 1)
+  expect_equal(read_block("02"), 2)
+  expect_equal(read_block("03"), 3)
+})
+
+test_that("per-run metadata.json is not clobbered by later runs in a shared bids_dir", {
+  skip_on_cran()
+  # make_report() writes the metadata json; a full html_report also renders it
+  skip_if_not(rmarkdown::pandoc_available(), "pandoc not available")
+
+  asc_files <- copy_demo_runs(3)
+  on.exit(unlink(dirname(asc_files[1]), recursive = TRUE), add = TRUE)
+
+  bids_dir <- tempfile("bids_runnum_meta_")
+  dir.create(bids_dir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+
+  for (i in seq_along(asc_files)) {
+    bidsify_run(asc_files[i], bids_dir, run_num = i, html_report = TRUE)
+  }
+
+  logs <- file.path(
+    bids_dir,
+    "derivatives",
+    "sub-AM22",
+    "ses-01",
+    "source",
+    "logs"
+  )
+
+  for (i in seq_along(asc_files)) {
+    rn <- sprintf("%02d", i)
+    meta_path <- file.path(
+      logs,
+      sprintf("task-assocmem_run-%s_metadata.json", rn)
+    )
+    expect_true(file.exists(meta_path))
+    meta <- jsonlite::read_json(meta_path)
+    # each run's metadata must reference its OWN source file and run number,
+    # not the last run processed into the shared bids_dir
+    expect_equal(meta$run, i)
+    expect_equal(basename(meta$source_file), basename(asc_files[i]))
+  }
+})


### PR DESCRIPTION
## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
<!-- Example: Fixed issue with function parameters (#123) -->

Fixed `run_num` override being ignored for epoch CSV and per-run `metadata.json` outputs when preprocessing separate single-block `.asc` files into a shared `bids_dir`.

### Problem Addressed
> When looping over separate single-block recordings and passing a per-file `run_num` to `bidsify()` (the run number is not forced at `load_asc()`, so every file loads as `block_1`), two outputs ignored the `block_1` → `block_<run_num>` rename and collapsed onto `run-01`: every run's `*_desc-preproc_pupil_epoch-<label>.csv` overwrote itself, and every run's `*_metadata.json` ended up with the last run's `source_file`/`call_stack`. The epoch-block rename updated only a local copy of the block-name vector and never wrote it back, while `make_report()` regenerated the metadata for *all* run directories found on disk (which accumulate across iterations) from the current in-memory object.

### Key Changes and Enhancements (Targeting `v3.2.1` [`Patch`] Release)
> 1. **Write the renamed epoch block key back onto the epoch list** in `run_bidsify()` so single-run `run_num` overrides route each epoch CSV (and epoch summary) to its correct `run-NN` instead of overwriting `run-01`.
> 2. **Scope per-run metadata regeneration to the current object** in `make_report()` via `get_block_numbers(eyeris)`, so sibling runs written in earlier iterations keep their own `source_file`/`call_stack` and are only read back (not clobbered) for the combined report.
> 3. **Added regression tests** (`test-bidsify-runnum-override.R`) covering both symptoms end-to-end.

### Acknowledgments
> 🙏 Thanks to @shawntz for flagging this issue.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed run labeling for single-run epoch outputs so each run keeps its own correct identifiers.
  * Prevented shared report metadata from being overwritten when multiple inputs are combined in one output location.

* **Tests**
  * Added regression coverage for distinct per-run epoch CSV output and correct metadata generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->