### PR TITLE
docs: add natively and Rescales to spell check wordlist

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -222,3 +222,5 @@ loaders
 roadmap
 Roadmap
 Diaconis
+natively
+Rescales


### PR DESCRIPTION
## Changelog entry

Added `natively` and `Rescales` to the spell check wordlist.

### Problem Addressed
The `spelling` check flagged `natively` and `Rescales` as unknown words, causing false-positive spell check failures.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)
1. **Added `natively` and `Rescales` to `inst/WORDLIST`** so the spell checker recognizes them as valid terms.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the word list with two additional terms: “natively” and “Rescales.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->