### PR TITLE
docs: add equivalent run_num example to multiple-runs vignette

### DIFF
--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -162,8 +162,7 @@ for (i in seq_along(asc_files)) {
 
 The only two changes from the first loop are: (1) `glassbox()` no longer receives
 `load_asc = list(block = i)`, so each file loads with its default single block;
-and (2) `bidsify()` now takes `run_num = i`, which relabels that block as
-`run-0i`. Everything else -- and every output file -- is the same.
+and (2) `bidsify()` now takes `run_num = i`, which relabels that block as `run-01`, `run-02`, etc. Everything else -- and every output file -- is the same.
 
 <div class="alert alert-warning" style="padding-bottom: 0;">
   ⚠️ <strong>The two forms are equivalent only for genuinely single-run

--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -118,9 +118,69 @@ What each piece is doing:
   silently ignored for objects that already contain multiple blocks.)
 </div>
 
+### The equivalent: label the run in `bidsify()` instead
+
+Setting the run number on **input** with `load_asc(block = i)` is the form we
+recommend, but it is not the only one. Because each single-run file already loads
+as one block by default, you can leave `load_asc` untouched and instead label
+each file on **output** with `bidsify(run_num = i)` -- exactly the "relabel a
+single-run object" use of `run_num` from the note above. This loop writes the
+same `run-01`, `run-02`, `run-03` derivatives as the one before it:
+
+```{r eval=FALSE}
+library(eyeris)
+
+dl <- path.expand("~/Downloads")
+asc_files <- file.path(dl, c(
+  "sub-AM22_t1_2026-03-09_20h46.11.141.asc",
+  "sub-AM22_t2_2026-03-09_21h08.15.079.asc",
+  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"
+))
+stopifnot(all(file.exists(asc_files)))
+
+output_dir <- path.expand("~/Documents/eyeris")
+
+for (i in seq_along(asc_files)) {
+  glassbox(asc_files[i], verbose = TRUE) |>
+    epoch(
+      events = "TST_trial-{trial}_{item}_{associate}",
+      limits = c(0, 0.1),
+      label  = "trialEpochs"
+    ) |>
+    bidsify(
+      bids_dir       = output_dir,
+      run_num        = i,
+      participant_id = "AM22",
+      session_num    = "01",
+      task_name      = "assocmem",
+      save_raw       = TRUE,
+      html_report    = TRUE,
+      report_seed    = 0
+    )
+}
+```
+
+The only two changes from the first loop are: (1) `glassbox()` no longer receives
+`load_asc = list(block = i)`, so each file loads with its default single block;
+and (2) `bidsify()` now takes `run_num = i`, which relabels that block as
+`run-0i`. Everything else -- and every output file -- is the same.
+
+<div class="alert alert-warning" style="padding-bottom: 0;">
+  ⚠️ <strong>The two forms are equivalent only for genuinely single-run
+  files.</strong> <code>run_num</code> relabels a file that resolves to
+  <em>one</em> block; if a file happens to contain multiple embedded recording
+  segments, <code>run_num</code> is <em>silently ignored</em> and the runs are
+  numbered from the embedded blocks instead. <code>load_asc(block = i)</code>
+  also <em>forces</em> the whole file into a single run, so it doubles as a guard
+  against accidentally-multi-segment files. If you prefer the
+  <code>run_num</code> form, it is worth running the
+  <a href="#sanity-check-confirm-one-run-per-file">sanity check</a> below to
+  confirm each file really is one run.
+</div>
+
 ### What you get
 
-After the loop finishes, your derivatives look like this (per-run data files
+After either loop finishes, your derivatives look like this (per-run data files
 shown for `run-01`; `run-02` and `run-03` follow the same pattern):
 
 ```

--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -168,7 +168,7 @@ and (2) `bidsify()` now takes `run_num = i`, which relabels that block as `run-0
   ⚠️ <strong>The two forms are equivalent only for genuinely single-run
   files.</strong> <code>run_num</code> relabels a file that resolves to
   <em>one</em> block; if a file happens to contain multiple embedded recording
-  segments, <code>run_num</code> is <em>silently ignored</em> and the runs are
+  segments, <code>run_num</code> is ignored (and <code>bidsify()</code> will emit a warning when <code>verbose = TRUE</code>) and the runs are
   numbered from the embedded blocks instead. <code>load_asc(block = i)</code>
   also <em>forces</em> the whole file into a single run, so it doubles as a guard
   against accidentally-multi-segment files. If you prefer the

--- a/vignettes/multiple-runs-separate-files.Rmd
+++ b/vignettes/multiple-runs-separate-files.Rmd
@@ -58,7 +58,7 @@ to `bidsify()`.
 
 ## The pattern
 
-Suppose participant `AM22` completed three runs of an associative-memory task,
+Suppose participant `AB01` completed three runs of an associative-memory task,
 each saved to its own file:
 
 ```{r eval=FALSE}
@@ -66,9 +66,9 @@ library(eyeris)
 
 dl <- path.expand("~/Downloads")
 asc_files <- file.path(dl, c(
-  "sub-AM22_t1_2026-03-09_20h46.11.141.asc",
-  "sub-AM22_t2_2026-03-09_21h08.15.079.asc",
-  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"
+  "sub-AB01_t1_2024-01-15_10h00.00.000.asc",
+  "sub-AB01_t2_2024-01-15_10h30.00.000.asc",
+  "sub-AB01_t3_2024-01-15_11h00.00.000.asc"
 ))
 stopifnot(all(file.exists(asc_files)))
 
@@ -83,7 +83,7 @@ for (i in seq_along(asc_files)) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -132,9 +132,9 @@ library(eyeris)
 
 dl <- path.expand("~/Downloads")
 asc_files <- file.path(dl, c(
-  "sub-AM22_t1_2026-03-09_20h46.11.141.asc",
-  "sub-AM22_t2_2026-03-09_21h08.15.079.asc",
-  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"
+  "sub-AB01_t1_2024-01-15_10h00.00.000.asc",
+  "sub-AB01_t2_2024-01-15_10h30.00.000.asc",
+  "sub-AB01_t3_2024-01-15_11h00.00.000.asc"
 ))
 stopifnot(all(file.exists(asc_files)))
 
@@ -150,7 +150,7 @@ for (i in seq_along(asc_files)) {
     bidsify(
       bids_dir       = output_dir,
       run_num        = i,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -186,19 +186,19 @@ shown for `run-01`; `run-02` and `run-03` follow the same pattern):
 ```
 eyeris
 └── derivatives
-    └── sub-AM22
+    └── sub-AB01
         └── ses-01
             ├── eye
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-timeseries.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-blinks.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-events.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-epoch_summary.csv
-            │   ├── sub-AM22_ses-01_task-assocmem_run-01_desc-preproc_pupil_epoch-trialepochs.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-blinks.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-events.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-epoch_summary.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-01_desc-preproc_pupil_epoch-trialepochs.csv
             │   ├── epoch_trialEpochs/   # per-trial confounds CSVs for run-01
             │   │   └── ...
-            │   ├── sub-AM22_ses-01_task-assocmem_run-02_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-02_desc-timeseries.csv
             │   ├── ...
-            │   ├── sub-AM22_ses-01_task-assocmem_run-03_desc-timeseries.csv
+            │   ├── sub-AB01_ses-01_task-assocmem_run-03_desc-timeseries.csv
             │   └── ...
             ├── source
             │   ├── figures
@@ -212,14 +212,14 @@ eyeris
             │       ├── task-assocmem_run-01_metadata.json
             │       ├── task-assocmem_run-02_metadata.json
             │       └── task-assocmem_run-03_metadata.json
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-01.html
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-02.html
-            ├── sub-AM22_task-assocmem_epoch-trialEpochs_run-03.html
-            └── sub-AM22_task-assocmem.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-01.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-02.html
+            ├── sub-AB01_task-assocmem_epoch-trialEpochs_run-03.html
+            └── sub-AB01_task-assocmem.html
 ```
 
 Every data file carries its `run-<index>`, and the top-level
-`sub-AM22_task-assocmem.html` report aggregates all three runs. For a full
+`sub-AB01_task-assocmem.html` report aggregates all three runs. For a full
 breakdown of what each derivative file contains, see the
 [Extracting Data Epochs and Exporting Pupil Data](epoching-bids-reports.html)
 vignette.
@@ -256,8 +256,8 @@ position. Two robust options:
 
 ```{r eval=FALSE}
 asc_files <- file.path(dl, c(
-  "sub-AM22_t1_2026-03-09_20h46.11.141.asc", # run 1
-  "sub-AM22_t3_2026-03-09_21h30.00.565.asc"  # run 3 (run 2 not collected)
+  "sub-AB01_t1_2024-01-15_10h00.00.000.asc", # run 1
+  "sub-AB01_t3_2024-01-15_11h00.00.000.asc"  # run 3 (run 2 not collected)
 ))
 run_nums <- c(1, 3) # the TRUE run numbers, in the same order as `asc_files`
 
@@ -270,7 +270,7 @@ for (i in seq_along(asc_files)) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -296,7 +296,7 @@ for (f in asc_files) {
     ) |>
     bidsify(
       bids_dir       = output_dir,
-      participant_id = "AM22",
+      participant_id = "AB01",
       session_num    = "01",
       task_name      = "assocmem",
       save_raw       = TRUE,
@@ -332,7 +332,7 @@ glassbox(asc_files[2], load_asc = list(block = 2), verbose = TRUE) |>
   ) |>
   bidsify(
     bids_dir       = output_dir,
-    participant_id = "AM22",
+    participant_id = "AB01",
     session_num    = "01",
     task_name      = "assocmem",
     save_raw       = TRUE,
@@ -389,7 +389,7 @@ glassbox(one_file_with_all_runs, load_asc = list(block = "auto")) |>
   ) |>
   bidsify(
     bids_dir       = output_dir,
-    participant_id = "AM22",
+    participant_id = "AB01",
     session_num    = "01",
     task_name      = "assocmem"
   )


### PR DESCRIPTION
## Changelog entry

Documented the equivalent `bidsify(run_num = i)` form in the "Preprocessing Multiple Runs Stored in Separate Files" vignette.

### Problem Addressed

The vignette taught only one way to assign a run number when each run lives in its own `.asc` file — setting it on input with `load_asc(block = i)` — leaving readers who instinctively reach for `run_num` in `bidsify()` without an in-doc equivalent or any note on how the two forms differ.

### Key Changes and Enhancements (Targeting the `3.2.0.9000` development cycle — documentation only, no version bump)

1. **Added the equivalent output-side loop** that leaves `load_asc()` at its default and labels each single-run file via `bidsify(run_num = i)`, producing the same `run-01`/`run-02`/`run-03` derivatives as the existing `load_asc(block = i)` loop.
2. **Called out the exact two differences** from the first loop and added a warning that the forms diverge for multi-segment files (`run_num` is silently ignored there, whereas `block = i` forces one run), linking to the existing sanity-check section.
3. Minor wording tweak so the shared "What you get" output tree reads as applying to **either** loop.
4. **Renamed the vignette's running example participant** from `sub-AM22` (realistic-looking id + timestamps) to `sub-AB01` with round `2024-01-15` timestamps, applied consistently across every code block, the derivatives tree, and the prose.

### Acknowledgments

🙏 Thanks to @shawntz for providing the example.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the vignette examples to use a new sample participant ID and matching output filenames throughout.
  * Added an alternative walkthrough for handling multiple runs stored in separate files, including a clearer option for assigning run numbers per file.
  * Clarified how run numbering behaves for multi-segment files and refreshed the example output tree and missing-run scenarios to match the updated walkthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->