### PR TITLE
docs: point package and site URLs at eyeris.shawnschwartz.com

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,6 @@ Suggests:
 VignetteBuilder: knitr
 License: MIT + file LICENSE
 Config/testthat/edition: 3
-URL: https://shawnschwartz.com/eyeris/, https://github.com/shawntz/eyeris/
+URL: https://eyeris.shawnschwartz.com/, https://github.com/shawntz/eyeris/
 BugReports: https://github.com/shawntz/eyeris/issues
 Config/roxygen2/version: 8.0.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
+# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://eyeris.shawnschwartz.com/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
 
 <!-- badges: start -->
 [![dev branch status](https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/badges/dev-branch-version.svg)](https://github.com/shawntz/eyeris/tree/dev)
@@ -83,7 +83,7 @@ preprocessing pipeline are required.
 tracker formats is on our roadmap, and we actively welcome community
 contributions of new loaders. If you would like to help add support for
 your tracker of choice, please open an issue or pull request — see the
-[contribution guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html)
+[contribution guidelines](https://eyeris.shawnschwartz.com/CONTRIBUTING.html)
 to get started.
 
 </div>
@@ -107,51 +107,51 @@ Below is a table of all main `eyeris` functions, organized by feature, with link
 
 | **Feature**                | **Function Documentation** | **Description** |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-| **Pipeline Orchestration** | [glassbox()](https://shawnschwartz.com/eyeris/reference/glassbox.html)                                              | Run the full recommended preprocessing pipeline with a single function call.                               |
-| **BIDSify**                | [bidsify()](https://shawnschwartz.com/eyeris/reference/bidsify.html)                                                | Create a BIDS-like directory structure for preprocessed data as well as interactive HTML reports for data and signal processing provenance.                                              |
-| **Data Loading**           | [load_asc()](https://shawnschwartz.com/eyeris/reference/load_asc.html)                                              | Load EyeLink `.asc` files into an `eyeris` object.                                                        |
-| **Blink Artifact Removal**          | [deblink()](https://shawnschwartz.com/eyeris/reference/deblink.html)                                                | Remove blink artifacts by extending and masking missing samples.                                           |
-| **Transient (Speed-Based) Artifact Removal**      | [detransient()](https://shawnschwartz.com/eyeris/reference/detransient.html)                                        | Remove transient spikes in the pupil signal using a moving MAD filter.                                     |
-| **Linear Interpolation**          | [interpolate()](https://shawnschwartz.com/eyeris/reference/interpolate.html)                                        | Interpolate missing (NA) samples in the pupil signal.                                                      |
-| **Lowpass Filtering**      | [lpfilt()](https://shawnschwartz.com/eyeris/reference/lpfilt.html)                                                  | Apply a Butterworth lowpass filter to the pupil signal.                                                    |
-| **Downsampling**           | [downsample()](https://shawnschwartz.com/eyeris/reference/downsample.html)                                          | Downsample the pupil signal to a lower sampling rate.                                                      |
-| **Binning**                | [bin()](https://shawnschwartz.com/eyeris/reference/bin.html)                                                        | Bin pupil data into specified time bins using mean or median.                                              |
-| **Detrending**             | [detrend()](https://shawnschwartz.com/eyeris/reference/detrend.html)                                                | Remove slow drifts from the pupil signal by linear detrending.                                             |
-| **Z-scoring**              | [zscore()](https://shawnschwartz.com/eyeris/reference/zscore.html)                                                  | Z-score the pupil signal within each block.                                                                |
-| **Confound Summary**       | [summarize_confounds()](https://shawnschwartz.com/eyeris/reference/summarize_confounds.html)                        | Summarize and visualize confounding variables for each preprocessing step.                                 |
-| **Epoching & Baselining**               | [epoch()](https://shawnschwartz.com/eyeris/reference/epoch.html)                                                    | Extract time-locked epochs from the continuous pupil signal.                                               |
-| **Plotting**               | [plot()](https://shawnschwartz.com/eyeris/reference/plot.eyeris.html)                                                 | Plot the pupil signal and preprocessing steps.                                                             |
-| **Gaze Heatmaps**          | [plot_gaze_heatmap()](https://shawnschwartz.com/eyeris/reference/plot_gaze_heatmap.html)                                      | Generate heatmaps of gaze position across the screen.                                                      |
-| **Binocular Correlation**  | [plot_binocular_correlation()](https://shawnschwartz.com/eyeris/reference/plot_binocular_correlation.html)                    | Compute correlation between left and right eye pupil signals.                                              |
-| **Demo (Monocular) Dataset**              | [eyelink_asc_demo_dataset()](https://shawnschwartz.com/eyeris/reference/eyelink_asc_demo_dataset.html)              | Load a demo monocular recording EyeLink dataset for testing and examples.                                                      |
-| **Demo (Binocular) Dataset**              | [eyelink_asc_binocular_demo_dataset()](https://shawnschwartz.com/eyeris/reference/eyelink_asc_binocular_demo_dataset.html)              | Load a demo binocular recording EyeLink dataset for testing and examples.                                                      |
-| **Logging Commands**       | [eyelogger()](https://shawnschwartz.com/eyeris/reference/eyelogger.html)                                            | Automatically capture all console output and errors to timestamped log files.                             |
-| **Database Storage**       | [eyeris_db_collect()](https://shawnschwartz.com/eyeris/reference/eyeris_db_collect.html)            | High-performance database storage and querying alternative to CSV files.                                   |
-| **Database Summary**       | [eyeris_db_summary()](https://shawnschwartz.com/eyeris/reference/eyeris_db_summary.html)                | Get comprehensive overview of database contents and metadata.                                              |
-| **Database Connection**    | [eyeris_db_connect()](https://shawnschwartz.com/eyeris/reference/eyeris_db_connect.html)                | Connect to eyeris databases for custom queries and operations.                                             |
-| **Database Export (Chunked)**    | [eyeris_db_to_chunked_files()](https://shawnschwartz.com/eyeris/reference/eyeris_db_to_chunked_files.html)                | Export large databases in configurable chunks with automatic file size limits.                                             |
-| **Database Export (Parquet)**    | [eyeris_db_to_parquet()](https://shawnschwartz.com/eyeris/reference/eyeris_db_to_parquet.html)                | Export database to high-performance Parquet format files.                                             |
-| **Read Parquet Files**    | [read_eyeris_parquet()](https://shawnschwartz.com/eyeris/reference/read_eyeris_parquet.html)                | Read and combine eyeris Parquet files with schema-aligned binding.                                             |
-| **Database Sharing (Split)**    | [eyeris_db_split_for_sharing()](https://shawnschwartz.com/eyeris/reference/eyeris_db_split_for_sharing.html)                | Split databases into chunks for easier sharing and collaboration.                                             |
-| **Database Sharing (Reconstruct)**    | [eyeris_db_reconstruct_from_chunks()](https://shawnschwartz.com/eyeris/reference/eyeris_db_reconstruct_from_chunks.html)                | Reconstruct complete databases from shared chunks.                                             |
-| **Custom Extensions**      | _See vignette: [Custom Extensions](https://shawnschwartz.com/eyeris/articles/custom-extensions.html)_ | Learn how to write your own pipeline steps and integrate them with `eyeris`.                               |
-| **Internal API Reference** | _See vignette: [Internal API Reference](https://shawnschwartz.com/eyeris/articles/internal-api.html)_ | Comprehensive documentation of all internal functions for advanced users and developers.                   |
+| **Pipeline Orchestration** | [glassbox()](https://eyeris.shawnschwartz.com/reference/glassbox.html)                                              | Run the full recommended preprocessing pipeline with a single function call.                               |
+| **BIDSify**                | [bidsify()](https://eyeris.shawnschwartz.com/reference/bidsify.html)                                                | Create a BIDS-like directory structure for preprocessed data as well as interactive HTML reports for data and signal processing provenance.                                              |
+| **Data Loading**           | [load_asc()](https://eyeris.shawnschwartz.com/reference/load_asc.html)                                              | Load EyeLink `.asc` files into an `eyeris` object.                                                        |
+| **Blink Artifact Removal**          | [deblink()](https://eyeris.shawnschwartz.com/reference/deblink.html)                                                | Remove blink artifacts by extending and masking missing samples.                                           |
+| **Transient (Speed-Based) Artifact Removal**      | [detransient()](https://eyeris.shawnschwartz.com/reference/detransient.html)                                        | Remove transient spikes in the pupil signal using a moving MAD filter.                                     |
+| **Linear Interpolation**          | [interpolate()](https://eyeris.shawnschwartz.com/reference/interpolate.html)                                        | Interpolate missing (NA) samples in the pupil signal.                                                      |
+| **Lowpass Filtering**      | [lpfilt()](https://eyeris.shawnschwartz.com/reference/lpfilt.html)                                                  | Apply a Butterworth lowpass filter to the pupil signal.                                                    |
+| **Downsampling**           | [downsample()](https://eyeris.shawnschwartz.com/reference/downsample.html)                                          | Downsample the pupil signal to a lower sampling rate.                                                      |
+| **Binning**                | [bin()](https://eyeris.shawnschwartz.com/reference/bin.html)                                                        | Bin pupil data into specified time bins using mean or median.                                              |
+| **Detrending**             | [detrend()](https://eyeris.shawnschwartz.com/reference/detrend.html)                                                | Remove slow drifts from the pupil signal by linear detrending.                                             |
+| **Z-scoring**              | [zscore()](https://eyeris.shawnschwartz.com/reference/zscore.html)                                                  | Z-score the pupil signal within each block.                                                                |
+| **Confound Summary**       | [summarize_confounds()](https://eyeris.shawnschwartz.com/reference/summarize_confounds.html)                        | Summarize and visualize confounding variables for each preprocessing step.                                 |
+| **Epoching & Baselining**               | [epoch()](https://eyeris.shawnschwartz.com/reference/epoch.html)                                                    | Extract time-locked epochs from the continuous pupil signal.                                               |
+| **Plotting**               | [plot()](https://eyeris.shawnschwartz.com/reference/plot.eyeris.html)                                                 | Plot the pupil signal and preprocessing steps.                                                             |
+| **Gaze Heatmaps**          | [plot_gaze_heatmap()](https://eyeris.shawnschwartz.com/reference/plot_gaze_heatmap.html)                                      | Generate heatmaps of gaze position across the screen.                                                      |
+| **Binocular Correlation**  | [plot_binocular_correlation()](https://eyeris.shawnschwartz.com/reference/plot_binocular_correlation.html)                    | Compute correlation between left and right eye pupil signals.                                              |
+| **Demo (Monocular) Dataset**              | [eyelink_asc_demo_dataset()](https://eyeris.shawnschwartz.com/reference/eyelink_asc_demo_dataset.html)              | Load a demo monocular recording EyeLink dataset for testing and examples.                                                      |
+| **Demo (Binocular) Dataset**              | [eyelink_asc_binocular_demo_dataset()](https://eyeris.shawnschwartz.com/reference/eyelink_asc_binocular_demo_dataset.html)              | Load a demo binocular recording EyeLink dataset for testing and examples.                                                      |
+| **Logging Commands**       | [eyelogger()](https://eyeris.shawnschwartz.com/reference/eyelogger.html)                                            | Automatically capture all console output and errors to timestamped log files.                             |
+| **Database Storage**       | [eyeris_db_collect()](https://eyeris.shawnschwartz.com/reference/eyeris_db_collect.html)            | High-performance database storage and querying alternative to CSV files.                                   |
+| **Database Summary**       | [eyeris_db_summary()](https://eyeris.shawnschwartz.com/reference/eyeris_db_summary.html)                | Get comprehensive overview of database contents and metadata.                                              |
+| **Database Connection**    | [eyeris_db_connect()](https://eyeris.shawnschwartz.com/reference/eyeris_db_connect.html)                | Connect to eyeris databases for custom queries and operations.                                             |
+| **Database Export (Chunked)**    | [eyeris_db_to_chunked_files()](https://eyeris.shawnschwartz.com/reference/eyeris_db_to_chunked_files.html)                | Export large databases in configurable chunks with automatic file size limits.                                             |
+| **Database Export (Parquet)**    | [eyeris_db_to_parquet()](https://eyeris.shawnschwartz.com/reference/eyeris_db_to_parquet.html)                | Export database to high-performance Parquet format files.                                             |
+| **Read Parquet Files**    | [read_eyeris_parquet()](https://eyeris.shawnschwartz.com/reference/read_eyeris_parquet.html)                | Read and combine eyeris Parquet files with schema-aligned binding.                                             |
+| **Database Sharing (Split)**    | [eyeris_db_split_for_sharing()](https://eyeris.shawnschwartz.com/reference/eyeris_db_split_for_sharing.html)                | Split databases into chunks for easier sharing and collaboration.                                             |
+| **Database Sharing (Reconstruct)**    | [eyeris_db_reconstruct_from_chunks()](https://eyeris.shawnschwartz.com/reference/eyeris_db_reconstruct_from_chunks.html)                | Reconstruct complete databases from shared chunks.                                             |
+| **Custom Extensions**      | _See vignette: [Custom Extensions](https://eyeris.shawnschwartz.com/articles/custom-extensions.html)_ | Learn how to write your own pipeline steps and integrate them with `eyeris`.                               |
+| **Internal API Reference** | _See vignette: [Internal API Reference](https://eyeris.shawnschwartz.com/articles/internal-api.html)_ | Comprehensive documentation of all internal functions for advanced users and developers.                   |
 
-> For a full list of all functions, see the [eyeris reference index](https://shawnschwartz.com/eyeris/reference/index.html).
+> For a full list of all functions, see the [eyeris reference index](https://eyeris.shawnschwartz.com/reference/index.html).
 
 ## 📚 Tutorials
 
 ### 🌟 Start Here
-- [✈ Getting Started: Complete (Opinionated) Pupillometry Pipeline Walkthrough](https://shawnschwartz.com/eyeris/articles/complete-pipeline.html)
-- [📁 Extracting Data Epochs and Exporting Pupil Data](https://shawnschwartz.com/eyeris/articles/epoching-bids-reports.html)
+- [✈ Getting Started: Complete (Opinionated) Pupillometry Pipeline Walkthrough](https://eyeris.shawnschwartz.com/articles/complete-pipeline.html)
+- [📁 Extracting Data Epochs and Exporting Pupil Data](https://eyeris.shawnschwartz.com/articles/epoching-bids-reports.html)
 
 ### 👀 Pupil Data Quality Control
-- [🔎 QC with Interactive Reports](https://shawnschwartz.com/eyeris/articles/reports.html)
+- [🔎 QC with Interactive Reports](https://eyeris.shawnschwartz.com/articles/reports.html)
 
 ### 💯 Advanced Topics
-- [🫀 Anatomy of an `eyeris` Object](https://shawnschwartz.com/eyeris/articles/anatomy.html)
-- [🛠 Building Your Own Custom Pipeline Extensions](https://shawnschwartz.com/eyeris/articles/custom-extensions.html)
-- [🗄 Database Storage Guide: Scalable Alternative to CSV Files](https://shawnschwartz.com/eyeris/articles/database-guide.html)
+- [🫀 Anatomy of an `eyeris` Object](https://eyeris.shawnschwartz.com/articles/anatomy.html)
+- [🛠 Building Your Own Custom Pipeline Extensions](https://eyeris.shawnschwartz.com/articles/custom-extensions.html)
+- [🗄 Database Storage Guide: Scalable Alternative to CSV Files](https://eyeris.shawnschwartz.com/articles/database-guide.html)
 
 ## 📦 Package Installation
 
@@ -399,7 +399,7 @@ eyeris_db_disconnect(con)
 
 > **💡 Pro Tip**: Use `csv_enabled = FALSE, db_enabled = TRUE` for cloud computing to maximize efficiency and minimize costs.
 
-> **📖 Complete Guide**: See the [Database Storage Guide](https://shawnschwartz.com/eyeris/articles/database-guide.html) for comprehensive tutorials, advanced usage, and real-world examples.
+> **📖 Complete Guide**: See the [Database Storage Guide](https://eyeris.shawnschwartz.com/articles/database-guide.html) for comprehensive tutorials, advanced usage, and real-world examples.
 
 ## 📁 BIDS-like file structure
 
@@ -580,11 +580,11 @@ depgraph::plot_dependency_graph(
 
 Thank you for considering contributing to the open-source `eyeris` R package; there are many ways one could contribute to `eyeris`.
 
-We believe the best preprocessing practices emerge from collective expertise and rigorous discussion. Please see the [contribution guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html) for more information on how to get started..
+We believe the best preprocessing practices emerge from collective expertise and rigorous discussion. Please see the [contribution guidelines](https://eyeris.shawnschwartz.com/CONTRIBUTING.html) for more information on how to get started..
 
 ## 📜 Code of Conduct
 
-Please note that the eyeris project is released with a [Contributor Code of Conduct](https://shawnschwartz.com/eyeris/CODE_OF_CONDUCT.html). By contributing
+Please note that the eyeris project is released with a [Contributor Code of Conduct](https://eyeris.shawnschwartz.com/CODE_OF_CONDUCT.html). By contributing
 to this project, you agree to abide by its terms.
 
 ## 💬 Suggestions, questions, issues?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd-->
 
-# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://shawnschwartz.com/eyeris/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
+# `eyeris`: Flexible, Extensible, & Reproducible Pupillometry Preprocessing <a href="https://eyeris.shawnschwartz.com/" title="eyeris website"><img src="https://raw.githubusercontent.com/shawntz/eyeris/refs/heads/dev/man/figures/logo.png" align="right" width="100" alt="eyeris website" /></a>
 
 <!-- badges: start -->
 
@@ -90,7 +90,7 @@ other tracker formats is on our roadmap, and we actively welcome
 community contributions of new loaders. If you would like to help add
 support for your tracker of choice, please open an issue or pull
 request — see the [contribution
-guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html) to get
+guidelines](https://eyeris.shawnschwartz.com/CONTRIBUTING.html) to get
 started.
 
 </div>
@@ -123,61 +123,61 @@ with links to their documentation and a brief description.
 
 | **Feature** | **Function Documentation** | **Description** |
 |----|----|----|
-| **Pipeline Orchestration** | [glassbox()](https://shawnschwartz.com/eyeris/reference/glassbox.html) | Run the full recommended preprocessing pipeline with a single function call. |
-| **BIDSify** | [bidsify()](https://shawnschwartz.com/eyeris/reference/bidsify.html) | Create a BIDS-like directory structure for preprocessed data as well as interactive HTML reports for data and signal processing provenance. |
-| **Data Loading** | [load_asc()](https://shawnschwartz.com/eyeris/reference/load_asc.html) | Load EyeLink `.asc` files into an `eyeris` object. |
-| **Blink Artifact Removal** | [deblink()](https://shawnschwartz.com/eyeris/reference/deblink.html) | Remove blink artifacts by extending and masking missing samples. |
-| **Transient (Speed-Based) Artifact Removal** | [detransient()](https://shawnschwartz.com/eyeris/reference/detransient.html) | Remove transient spikes in the pupil signal using a moving MAD filter. |
-| **Linear Interpolation** | [interpolate()](https://shawnschwartz.com/eyeris/reference/interpolate.html) | Interpolate missing (NA) samples in the pupil signal. |
-| **Lowpass Filtering** | [lpfilt()](https://shawnschwartz.com/eyeris/reference/lpfilt.html) | Apply a Butterworth lowpass filter to the pupil signal. |
-| **Downsampling** | [downsample()](https://shawnschwartz.com/eyeris/reference/downsample.html) | Downsample the pupil signal to a lower sampling rate. |
-| **Binning** | [bin()](https://shawnschwartz.com/eyeris/reference/bin.html) | Bin pupil data into specified time bins using mean or median. |
-| **Detrending** | [detrend()](https://shawnschwartz.com/eyeris/reference/detrend.html) | Remove slow drifts from the pupil signal by linear detrending. |
-| **Z-scoring** | [zscore()](https://shawnschwartz.com/eyeris/reference/zscore.html) | Z-score the pupil signal within each block. |
-| **Confound Summary** | [summarize_confounds()](https://shawnschwartz.com/eyeris/reference/summarize_confounds.html) | Summarize and visualize confounding variables for each preprocessing step. |
-| **Epoching & Baselining** | [epoch()](https://shawnschwartz.com/eyeris/reference/epoch.html) | Extract time-locked epochs from the continuous pupil signal. |
-| **Plotting** | [plot()](https://shawnschwartz.com/eyeris/reference/plot.eyeris.html) | Plot the pupil signal and preprocessing steps. |
-| **Gaze Heatmaps** | [plot_gaze_heatmap()](https://shawnschwartz.com/eyeris/reference/plot_gaze_heatmap.html) | Generate heatmaps of gaze position across the screen. |
-| **Binocular Correlation** | [plot_binocular_correlation()](https://shawnschwartz.com/eyeris/reference/plot_binocular_correlation.html) | Compute correlation between left and right eye pupil signals. |
-| **Demo (Monocular) Dataset** | [eyelink_asc_demo_dataset()](https://shawnschwartz.com/eyeris/reference/eyelink_asc_demo_dataset.html) | Load a demo monocular recording EyeLink dataset for testing and examples. |
-| **Demo (Binocular) Dataset** | [eyelink_asc_binocular_demo_dataset()](https://shawnschwartz.com/eyeris/reference/eyelink_asc_binocular_demo_dataset.html) | Load a demo binocular recording EyeLink dataset for testing and examples. |
-| **Logging Commands** | [eyelogger()](https://shawnschwartz.com/eyeris/reference/eyelogger.html) | Automatically capture all console output and errors to timestamped log files. |
-| **Database Storage** | [eyeris_db_collect()](https://shawnschwartz.com/eyeris/reference/eyeris_db_collect.html) | High-performance database storage and querying alternative to CSV files. |
-| **Database Summary** | [eyeris_db_summary()](https://shawnschwartz.com/eyeris/reference/eyeris_db_summary.html) | Get comprehensive overview of database contents and metadata. |
-| **Database Connection** | [eyeris_db_connect()](https://shawnschwartz.com/eyeris/reference/eyeris_db_connect.html) | Connect to eyeris databases for custom queries and operations. |
-| **Database Export (Chunked)** | [eyeris_db_to_chunked_files()](https://shawnschwartz.com/eyeris/reference/eyeris_db_to_chunked_files.html) | Export large databases in configurable chunks with automatic file size limits. |
-| **Database Export (Parquet)** | [eyeris_db_to_parquet()](https://shawnschwartz.com/eyeris/reference/eyeris_db_to_parquet.html) | Export database to high-performance Parquet format files. |
-| **Read Parquet Files** | [read_eyeris_parquet()](https://shawnschwartz.com/eyeris/reference/read_eyeris_parquet.html) | Read and combine eyeris Parquet files with schema-aligned binding. |
-| **Database Sharing (Split)** | [eyeris_db_split_for_sharing()](https://shawnschwartz.com/eyeris/reference/eyeris_db_split_for_sharing.html) | Split databases into chunks for easier sharing and collaboration. |
-| **Database Sharing (Reconstruct)** | [eyeris_db_reconstruct_from_chunks()](https://shawnschwartz.com/eyeris/reference/eyeris_db_reconstruct_from_chunks.html) | Reconstruct complete databases from shared chunks. |
-| **Custom Extensions** | *See vignette: [Custom Extensions](https://shawnschwartz.com/eyeris/articles/custom-extensions.html)* | Learn how to write your own pipeline steps and integrate them with `eyeris`. |
-| **Internal API Reference** | *See vignette: [Internal API Reference](https://shawnschwartz.com/eyeris/articles/internal-api.html)* | Comprehensive documentation of all internal functions for advanced users and developers. |
+| **Pipeline Orchestration** | [glassbox()](https://eyeris.shawnschwartz.com/reference/glassbox.html) | Run the full recommended preprocessing pipeline with a single function call. |
+| **BIDSify** | [bidsify()](https://eyeris.shawnschwartz.com/reference/bidsify.html) | Create a BIDS-like directory structure for preprocessed data as well as interactive HTML reports for data and signal processing provenance. |
+| **Data Loading** | [load_asc()](https://eyeris.shawnschwartz.com/reference/load_asc.html) | Load EyeLink `.asc` files into an `eyeris` object. |
+| **Blink Artifact Removal** | [deblink()](https://eyeris.shawnschwartz.com/reference/deblink.html) | Remove blink artifacts by extending and masking missing samples. |
+| **Transient (Speed-Based) Artifact Removal** | [detransient()](https://eyeris.shawnschwartz.com/reference/detransient.html) | Remove transient spikes in the pupil signal using a moving MAD filter. |
+| **Linear Interpolation** | [interpolate()](https://eyeris.shawnschwartz.com/reference/interpolate.html) | Interpolate missing (NA) samples in the pupil signal. |
+| **Lowpass Filtering** | [lpfilt()](https://eyeris.shawnschwartz.com/reference/lpfilt.html) | Apply a Butterworth lowpass filter to the pupil signal. |
+| **Downsampling** | [downsample()](https://eyeris.shawnschwartz.com/reference/downsample.html) | Downsample the pupil signal to a lower sampling rate. |
+| **Binning** | [bin()](https://eyeris.shawnschwartz.com/reference/bin.html) | Bin pupil data into specified time bins using mean or median. |
+| **Detrending** | [detrend()](https://eyeris.shawnschwartz.com/reference/detrend.html) | Remove slow drifts from the pupil signal by linear detrending. |
+| **Z-scoring** | [zscore()](https://eyeris.shawnschwartz.com/reference/zscore.html) | Z-score the pupil signal within each block. |
+| **Confound Summary** | [summarize_confounds()](https://eyeris.shawnschwartz.com/reference/summarize_confounds.html) | Summarize and visualize confounding variables for each preprocessing step. |
+| **Epoching & Baselining** | [epoch()](https://eyeris.shawnschwartz.com/reference/epoch.html) | Extract time-locked epochs from the continuous pupil signal. |
+| **Plotting** | [plot()](https://eyeris.shawnschwartz.com/reference/plot.eyeris.html) | Plot the pupil signal and preprocessing steps. |
+| **Gaze Heatmaps** | [plot_gaze_heatmap()](https://eyeris.shawnschwartz.com/reference/plot_gaze_heatmap.html) | Generate heatmaps of gaze position across the screen. |
+| **Binocular Correlation** | [plot_binocular_correlation()](https://eyeris.shawnschwartz.com/reference/plot_binocular_correlation.html) | Compute correlation between left and right eye pupil signals. |
+| **Demo (Monocular) Dataset** | [eyelink_asc_demo_dataset()](https://eyeris.shawnschwartz.com/reference/eyelink_asc_demo_dataset.html) | Load a demo monocular recording EyeLink dataset for testing and examples. |
+| **Demo (Binocular) Dataset** | [eyelink_asc_binocular_demo_dataset()](https://eyeris.shawnschwartz.com/reference/eyelink_asc_binocular_demo_dataset.html) | Load a demo binocular recording EyeLink dataset for testing and examples. |
+| **Logging Commands** | [eyelogger()](https://eyeris.shawnschwartz.com/reference/eyelogger.html) | Automatically capture all console output and errors to timestamped log files. |
+| **Database Storage** | [eyeris_db_collect()](https://eyeris.shawnschwartz.com/reference/eyeris_db_collect.html) | High-performance database storage and querying alternative to CSV files. |
+| **Database Summary** | [eyeris_db_summary()](https://eyeris.shawnschwartz.com/reference/eyeris_db_summary.html) | Get comprehensive overview of database contents and metadata. |
+| **Database Connection** | [eyeris_db_connect()](https://eyeris.shawnschwartz.com/reference/eyeris_db_connect.html) | Connect to eyeris databases for custom queries and operations. |
+| **Database Export (Chunked)** | [eyeris_db_to_chunked_files()](https://eyeris.shawnschwartz.com/reference/eyeris_db_to_chunked_files.html) | Export large databases in configurable chunks with automatic file size limits. |
+| **Database Export (Parquet)** | [eyeris_db_to_parquet()](https://eyeris.shawnschwartz.com/reference/eyeris_db_to_parquet.html) | Export database to high-performance Parquet format files. |
+| **Read Parquet Files** | [read_eyeris_parquet()](https://eyeris.shawnschwartz.com/reference/read_eyeris_parquet.html) | Read and combine eyeris Parquet files with schema-aligned binding. |
+| **Database Sharing (Split)** | [eyeris_db_split_for_sharing()](https://eyeris.shawnschwartz.com/reference/eyeris_db_split_for_sharing.html) | Split databases into chunks for easier sharing and collaboration. |
+| **Database Sharing (Reconstruct)** | [eyeris_db_reconstruct_from_chunks()](https://eyeris.shawnschwartz.com/reference/eyeris_db_reconstruct_from_chunks.html) | Reconstruct complete databases from shared chunks. |
+| **Custom Extensions** | *See vignette: [Custom Extensions](https://eyeris.shawnschwartz.com/articles/custom-extensions.html)* | Learn how to write your own pipeline steps and integrate them with `eyeris`. |
+| **Internal API Reference** | *See vignette: [Internal API Reference](https://eyeris.shawnschwartz.com/articles/internal-api.html)* | Comprehensive documentation of all internal functions for advanced users and developers. |
 
 > For a full list of all functions, see the [eyeris reference
-> index](https://shawnschwartz.com/eyeris/reference/index.html).
+> index](https://eyeris.shawnschwartz.com/reference/index.html).
 
 ## 📚 Tutorials
 
 ### 🌟 Start Here
 
 - [✈ Getting Started: Complete (Opinionated) Pupillometry Pipeline
-  Walkthrough](https://shawnschwartz.com/eyeris/articles/complete-pipeline.html)
+  Walkthrough](https://eyeris.shawnschwartz.com/articles/complete-pipeline.html)
 - [📁 Extracting Data Epochs and Exporting Pupil
-  Data](https://shawnschwartz.com/eyeris/articles/epoching-bids-reports.html)
+  Data](https://eyeris.shawnschwartz.com/articles/epoching-bids-reports.html)
 
 ### 👀 Pupil Data Quality Control
 
 - [🔎 QC with Interactive
-  Reports](https://shawnschwartz.com/eyeris/articles/reports.html)
+  Reports](https://eyeris.shawnschwartz.com/articles/reports.html)
 
 ### 💯 Advanced Topics
 
 - [🫀 Anatomy of an `eyeris`
-  Object](https://shawnschwartz.com/eyeris/articles/anatomy.html)
+  Object](https://eyeris.shawnschwartz.com/articles/anatomy.html)
 - [🛠 Building Your Own Custom Pipeline
-  Extensions](https://shawnschwartz.com/eyeris/articles/custom-extensions.html)
+  Extensions](https://eyeris.shawnschwartz.com/articles/custom-extensions.html)
 - [🗄 Database Storage Guide: Scalable Alternative to CSV
-  Files](https://shawnschwartz.com/eyeris/articles/database-guide.html)
+  Files](https://eyeris.shawnschwartz.com/articles/database-guide.html)
 
 ## 📦 Package Installation
 
@@ -526,7 +526,7 @@ eyeris_db_disconnect(con)
 > computing to maximize efficiency and minimize costs.
 
 > **📖 Complete Guide**: See the [Database Storage
-> Guide](https://shawnschwartz.com/eyeris/articles/database-guide.html)
+> Guide](https://eyeris.shawnschwartz.com/articles/database-guide.html)
 > for comprehensive tutorials, advanced usage, and real-world examples.
 
 ## 📁 BIDS-like file structure
@@ -722,13 +722,13 @@ package; there are many ways one could contribute to `eyeris`.
 
 We believe the best preprocessing practices emerge from collective
 expertise and rigorous discussion. Please see the [contribution
-guidelines](https://shawnschwartz.com/eyeris/CONTRIBUTING.html) for more
+guidelines](https://eyeris.shawnschwartz.com/CONTRIBUTING.html) for more
 information on how to get started..
 
 ## 📜 Code of Conduct
 
 Please note that the eyeris project is released with a [Contributor Code
-of Conduct](https://shawnschwartz.com/eyeris/CODE_OF_CONDUCT.html). By
+of Conduct](https://eyeris.shawnschwartz.com/CODE_OF_CONDUCT.html). By
 contributing to this project, you agree to abide by its terms.
 
 ## 💬 Suggestions, questions, issues?

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://shawnschwartz.com/eyeris/
+url: https://eyeris.shawnschwartz.com/
 
 news:
     cran_dates: true

--- a/man/eyeris-package.Rd
+++ b/man/eyeris-package.Rd
@@ -13,7 +13,7 @@ Pupillometry offers a non-invasive window into the mind and has been used extens
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://shawnschwartz.com/eyeris/}
+  \item \url{https://eyeris.shawnschwartz.com/}
   \item \url{https://github.com/shawntz/eyeris/}
   \item Report bugs at \url{https://github.com/shawntz/eyeris/issues}
 }


### PR DESCRIPTION
## Changelog entry

Fixed the documented package/site URL, which pointed at the now-404 `https://shawnschwartz.com/eyeris/` instead of the live `https://eyeris.shawnschwartz.com/`.

### Problem Addressed
> The eyeris pkgdown site is served at `https://eyeris.shawnschwartz.com/`, but the package's documented URL still pointed at `https://shawnschwartz.com/eyeris/`, which now returns **404**. This meant broken links throughout the README, a CRAN-facing `DESCRIPTION` URL that fails URL checks, and — via `_pkgdown.yml` — incorrect canonical URLs, sitemap, and search-index entries for the entire documentation site.

### Key Changes and Enhancements (Targeting next `Patch` [docs] release)
> Migrated every `shawnschwartz.com/eyeris` reference to `eyeris.shawnschwartz.com` (the `/eyeris/` path segment collapses to the subdomain root; all migrated paths verified to return HTTP 200):
>
> 1. **`_pkgdown.yml`** `url:` — drives the site's canonical links, sitemap, and search index.
> 2. **`DESCRIPTION`** `URL:` — CRAN-facing package metadata (`github.com/shawntz/eyeris/` link left intact).
> 3. **`man/eyeris-package.Rd`** — the generated `\url{}` kept in sync with `DESCRIPTION`.
> 4. **`README.Rmd` + `README.md`** — all reference/article/CONTRIBUTING/CODE_OF_CONDUCT links (GitHub `raw.githubusercontent.com` image sources left untouched).

### Acknowledgments
> 🙏 Thanks to @shawntz for flagging the correct website URL.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md
