### PR TITLE
Add ggplot2, patchwork, and reaborn to Makefile getdeps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ uninstall:
 # install package deps ----------------------------------------------------
 getdeps:
 	@echo "[INFO] Installing R package dependencies..."
-	Rscript -e "deps <- c('eyelinker', 'dplyr', 'gsignal', 'tidyr', 'zoo', 'purrr', 'cli', 'rlang', 'stringr', 'utils', 'stats', 'graphics', 'grDevices', 'progress', 'data.table', 'withr', 'lifecycle', 'MASS', 'viridis', 'fields', 'jsonlite', 'rmarkdown', 'DBI', 'glue', 'base64enc'); install.packages(deps, repos = 'http://cran.us.r-project.org')" > /dev/null
+	Rscript -e "deps <- c('eyelinker', 'dplyr', 'gsignal', 'tidyr', 'zoo', 'purrr', 'cli', 'rlang', 'stringr', 'utils', 'stats', 'graphics', 'grDevices', 'progress', 'data.table', 'withr', 'lifecycle', 'MASS', 'viridis', 'fields', 'jsonlite', 'rmarkdown', 'DBI', 'glue', 'base64enc', 'reaborn', 'ggplot2', 'patchwork'); install.packages(deps, repos = 'http://cran.us.r-project.org')" > /dev/null
 	Rscript -e "install.packages('remotes', repos='https://cloud.r-project.org')" > /dev/null
 	Rscript -e "remotes::install_github('crsh/depgraph')" > /dev/null
 	@echo "[OKAY] Dependencies installed successfully!\n"


### PR DESCRIPTION
## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
Added `ggplot2` and `patchwork` to the Makefile `getdeps` install target.

### Problem Addressed
The Makefile `getdeps` target did not install some packages used during development, so `make getdeps` did not fully provision a dev environment.

### Key Changes and Enhancements (Targeting `vX.Y.Z` `Patch` Release)
> 1. Extended the `deps` vector in the Makefile `getdeps` target with `ggplot2`, `patchwork`, and `reaborn`.

⚠️ Note: `reaborn` is included but is not a resolvable CRAN package; `install.packages()` will skip it with a warning.

### Acknowledgments
🙏 Thanks to @shawntz.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project setup to include additional package dependencies required for installation and related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->