### PR TITLE
chore: bump version to 3.2.0.9004

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 3.2.0.9003
-Date: 2026-07-16
+Version: 3.2.0.9004
+Date: 2026-07-18
 Language: en-US
 Authors@R: 
   c(


### PR DESCRIPTION
## Changelog entry

Bump development version to 3.2.0.9004.

### Problem Addressed
Routine development version increment following the previous release cycle. No functional code changes.

### Key Changes and Enhancements (Targeting `v3.2.0.9004` [`Patch`] Release)

1. **Bump `Version`** in `DESCRIPTION` from `3.2.0.9003` to `3.2.0.9004`.
2. **Update `Date`** in `DESCRIPTION` to `2026-07-18`.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [x] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md