### PR TITLE
Add "jitter" to spell-check wordlist

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -88,6 +88,7 @@ ie
 indability
 ish
 iteratively
+jitter
 JT
 Kret
 LEGO


### PR DESCRIPTION
## Changelog entry

<!-- Add your changelog entry below. It will be automatically added to NEWS.md -->
Added `jitter` to the spell-check wordlist.

### Problem Addressed
The word `jitter` was not present in `inst/WORDLIST`, which would cause `R CMD check` / spell-check to flag it as a misspelling.

### Key Changes and Enhancements (Targeting `vX.Y.Z` [`Patch`] Release)
1. **Added `jitter` to `inst/WORDLIST`** (in alphabetical order, between `iteratively` and `JT`) so it is recognized as a valid term during spell-checking.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [ ] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “jitter” to the supported word list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->