### PR TITLE
Bump version to 3.2.0.9005

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 3.2.0.9004
+Version: 3.2.0.9005
 Date: 2026-07-18
 Language: en-US
 Authors@R: 


### PR DESCRIPTION
## Changelog entry

Development version bump to 3.2.0.9005.

### Problem Addressed
Routine version bump for ongoing development.

### Key Changes and Enhancements (Targeting `v3.2.0.9005` [`Dev`] Release)
Bumped the package version in `DESCRIPTION` from `3.2.0.9004` to `3.2.0.9005`.

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [x] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 3.2.0.9004 to 3.2.0.9005.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->