### PR TITLE
chore: bump version to 3.2.0.9006

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eyeris
 Type: Package
 Title: Flexible, Extensible, & Reproducible Pupillometry Preprocessing
-Version: 3.2.0.9005
+Version: 3.2.0.9006
 Date: 2026-07-18
 Language: en-US
 Authors@R: 


### PR DESCRIPTION
## Changelog entry

Bumped development version to `3.2.0.9006`.

### Problem Addressed
Routine development version bump to mark the next iteration of work on the `dev` branch.

### Key Changes and Enhancements (Targeting `v3.2.0.9006` [`Patch`] Release)

1. **Bumped `Version` in `DESCRIPTION`** from `3.2.0.9005` to `3.2.0.9006`.

### Acknowledgments
N/A

## Breaking changes checklist

- [ ] This PR includes breaking changes
- [x] Version number has been bumped appropriately
- [ ] Migration guide added to NEWS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 3.2.0.9006.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->